### PR TITLE
fix: correct branch name parsing in git operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.1.0"
+version = "1.1.1"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/commands/git_operations.py
+++ b/src/pygitgo/commands/git_operations.py
@@ -9,10 +9,9 @@ DEFAULT_MAIN_BRANCH = "main"
 
 
 def get_current_branch():
-    branch = run_command(["git", "branch", "--show-current"])
-    if branch.strip() == "":
-        branch = git_new_branch(DEFAULT_MAIN_BRANCH)
-
+    branch = run_command(["git", "branch", "--show-current"]).strip()
+    if not branch:
+        branch = run_command(["git", "rev-parse", "--short", "HEAD"]).strip()
     return branch
 
 def get_main_branch():
@@ -20,7 +19,7 @@ def get_main_branch():
     if isinstance(main_branch, subprocess.CalledProcessError):
         return DEFAULT_MAIN_BRANCH
     
-    return main_branch.split("HEAD branch:")[-1].strip() if "HEAD branch:" in main_branch else DEFAULT_MAIN_BRANCH
+    return main_branch.split("HEAD branch:")[-1].strip().splitlines()[0].strip() if "HEAD branch:" in main_branch else DEFAULT_MAIN_BRANCH
 
 def is_branch_exist(branch):
     return bool(run_command(["git", "branch", "-r", "--list", f"*/{branch}"])) or bool(run_command(["git", "branch", "--list", branch]))

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -8,20 +8,20 @@ import subprocess
 import sys
 
 def jump_operations_help():
-    warning("\nJump Operations Help:\n")
-    info("Usage: gitgo jump [branch]\n")
-    info("Arguments:")
-    info("  branch   The name of the branch to jump to.\n")
+    warning("\nUsage: gitgo jump <branch>\n")
+    warning("branch: The name of the branch to jump to.\n")
 
-def undo_jump_operation(original_branch, has_changes):
-    if not has_changes.strip():
+def undo_jump_operation(original_branch, stashed_code, created_branch=None):
+    if created_branch:
+        run_command(["git", "checkout", original_branch], loading_msg=f"Jumping you back to the original branch '{original_branch}'...")
+        run_command(["git", "branch", "-D", created_branch], allow_fail=True, loading_msg=f"Removing the empty branch '{created_branch}'...")
+    else:
+        run_command(["git", "reset", "--hard", "HEAD"], loading_msg="Canceling... Putting your files back exactly how they were...")
         run_command(['git', 'checkout', original_branch], loading_msg=f"Jumping you back to the original branch '{original_branch}'...")
-        success(f"\nOkay! You are back to the original branch '{original_branch}'.")
-        sys.exit(0)
 
-    run_command(["git", "reset", "--hard", "HEAD"], loading_msg="Canceling... Putting your files back exactly how they were...")
-    run_command(['git', 'checkout', original_branch], loading_msg=f"Jumping you back to the original branch '{original_branch}'...")
-    run_command(["git", "stash", "pop"], loading_msg="Restoring your unsaved changes...")
+    if stashed_code:
+        run_command(["git", "stash", "pop"], loading_msg="Restoring your unsaved changes...")
+
     success(f"\nCanceled safely!")
     success(f"You are back on your original branch '{original_branch}', and your code is totally safe.\n")
 
@@ -38,7 +38,7 @@ def jump_operation(arguments):
         warning(f"\nYou are already on branch '{target_branch}'.\n")
         sys.exit(0)
 
-    has_changes = run_command(['git', 'status', '--porcelain'], allow_fail=True)
+    has_changes = run_command(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
     if isinstance(has_changes, subprocess.CalledProcessError):
         warning("\nUnable to check for uncommitted changes. Please ensure you're in a valid git repository.")
         sys.exit(1)
@@ -48,15 +48,17 @@ def jump_operation(arguments):
         info("\nYou have unsaved changes here.")
         user_input = input("Do you want to move these changes to your new branch? (y/n): ").strip().lower()
         if user_input != 'y':
-            warning("\nOkay! Leaving your changes here. Jumping without them...\n")
+            warning("\nYou cannot switch branches with unsaved changes. Jump canceled.\n")
+            sys.exit(0)
         else:
-            stash_result = run_command(["git", "stash", "push", "-m", "GitGo Jump Auto-Stash"], allow_fail=True, loading_msg="Saving your changes before jumping...")
+            stash_result = run_command(["git", "stash", "push", "-u", "-m", "GitGo Jump Auto-Stash"], allow_fail=True, loading_msg="Saving your changes before jumping...")
             if isinstance(stash_result, subprocess.CalledProcessError):
                 warning("\nFailed to save your changes. Please resolve any issues and try again.")
                 sys.exit(1)
             info("\nYour changes have been saved. Jumping to the new branch...")
             stashed_code = True
             
+    created_branch = None
     if not is_branch_exist(target_branch):
         warning(f"\nBranch '{target_branch}' does not exist.\n")
         user_input = input("Do you want to create it and jump to it? (y/n): ").strip().lower()
@@ -68,6 +70,7 @@ def jump_operation(arguments):
             sys.exit(0)
         
         git_new_branch(target_branch)
+        created_branch = target_branch
     else:
         run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...")
 
@@ -78,7 +81,7 @@ def jump_operation(arguments):
         warning(f"\nFailed to pull updates from '{main_branch}'. Make sure you have internet or the remote branch exists.")
         user_input = input("Do you want to stay on the new branch without the latest updates? (y/n): ").strip().lower()
         if user_input != 'y':
-            undo_jump_operation(original_branch, has_changes if stashed_code else "")
+            undo_jump_operation(original_branch, stashed_code, created_branch)
             sys.exit(1)
         else:
             success(f"\nOkay! You are on the new branch, but without the latest updates from '{main_branch}'.")
@@ -93,12 +96,12 @@ def jump_operation(arguments):
             conflict_choice = input("Do you want to fix it yourself? (y/n): ").strip().lower()
 
             if conflict_choice != 'y':
-                undo_jump_operation(original_branch, has_changes)
+                undo_jump_operation(original_branch, stashed_code, created_branch)
                 sys.exit(0)
             else:
                 success("\nOkay! You are on the new branch with your code.")
-                warning("Please open your code editor RIGHT NOW to fix the conflicts!\n")
-                run_command(["git", "stash", "drop"], allow_fail=True, loading_msg="Cleaning up the temporary stash...")
+                warning("Please open your code editor RIGHT NOW to fix the conflicts!")
+                info("Your stash backup is still saved. Run 'gitgo state list' to see it.\n")
                 sys.exit(0)
         else:
             run_command(["git", "stash", "drop"], allow_fail=True, loading_msg="Cleaning up the temporary stash...")
@@ -108,4 +111,3 @@ def jump_operation(arguments):
     else:
         success(f"\nSuccess! You are now on '{target_branch}'.\n")
         sys.exit(0)
-

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -91,10 +91,8 @@ def ask_state_id(save_states):
 def state_list(arguments):
     if len(arguments) > 1:
         if arguments[1] in ("-h", "--help", "help"):
-            print("\nDisplay all saved states.\n")
-            warning("\nUsage:\n")
-            print("  gitgo state list        # Show all saved states")
-            print("  gitgo state -l          # Alias\n")
+            warning("\nUsage: gitgo state list\n")
+            warning("list: Display all saved states (Alias: -l)\n")
             sys.exit(0)
         error("\nToo many arguments for list operation!\n")
         sys.exit(1)

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -203,11 +203,11 @@ def user_management(operation):
     if len(operation) > 1:
         if operation[1] in HELP_COMMANDS:
             if operation[0] == "login":
-                info("\nUsage: gitgo user login\n")
-                info("Sets up your Git user identity (name and email) for commits.\n")
+                warning("\nUsage: gitgo user login\n")
+                warning("login: Sets up your Git user identity (name and email) for commits.\n")
             elif operation[0] == "logout":
-                info("\nUsage: gitgo user logout\n")
-                info("Removes your Git user identity configuration.\n")
+                warning("\nUsage: gitgo user logout\n")
+                warning("logout: Removes your Git user identity configuration.\n")
             else:
                 warning("\nUsage: gitgo user <login | logout>\n")
                 warning("login: Configure your Git user identity.")

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -8,18 +8,30 @@ def check_pytest_system_exit(function):
 
     return exc_info.value.code
 
-def test_undo_jump_operation_no_changes(mocker):
-    mocker.patch('pygitgo.commands.jump.run_command', return_value="")
-        
-    assert check_pytest_system_exit(lambda: undo_jump_operation("original_branch", "")) == 0
-
-def test_undo_jump_operation_has_changes(mocker):
-    fake_run = mocker.patch('pygitgo.commands.jump.run_command', side_effect=["", None, None])
+def test_undo_jump_operation_no_stash(mocker):
+    fake_run = mocker.patch('pygitgo.commands.jump.run_command', return_value="")
     
-    undo_jump_operation("original_branch", "some changes")
+    undo_jump_operation("original_branch", False)
     
     fake_run.assert_any_call(["git", "reset", "--hard", "HEAD"], loading_msg="Canceling... Putting your files back exactly how they were...")
-    fake_run.assert_any_call(['git', 'checkout', "original_branch"], loading_msg=f"Jumping you back to the original branch 'original_branch'...")
+    fake_run.assert_any_call(['git', 'checkout', "original_branch"], loading_msg="Jumping you back to the original branch 'original_branch'...")
+
+def test_undo_jump_operation_with_stash(mocker):
+    fake_run = mocker.patch('pygitgo.commands.jump.run_command', return_value="")
+    
+    undo_jump_operation("original_branch", True)
+    
+    fake_run.assert_any_call(["git", "reset", "--hard", "HEAD"], loading_msg="Canceling... Putting your files back exactly how they were...")
+    fake_run.assert_any_call(['git', 'checkout', "original_branch"], loading_msg="Jumping you back to the original branch 'original_branch'...")
+    fake_run.assert_any_call(["git", "stash", "pop"], loading_msg="Restoring your unsaved changes...")
+
+def test_undo_jump_operation_deletes_ghost_branch(mocker):
+    fake_run = mocker.patch('pygitgo.commands.jump.run_command', return_value="")
+    
+    undo_jump_operation("original_branch", True, created_branch="ghost-branch")
+    
+    fake_run.assert_any_call(['git', 'checkout', "original_branch"], loading_msg="Jumping you back to the original branch 'original_branch'...")
+    fake_run.assert_any_call(["git", "branch", "-D", "ghost-branch"], allow_fail=True, loading_msg="Removing the empty branch 'ghost-branch'...")
     fake_run.assert_any_call(["git", "stash", "pop"], loading_msg="Restoring your unsaved changes...")
 
 def test_jump_operation_help(mocker):
@@ -55,30 +67,23 @@ def test_jump_operation_not_valid_repo(mocker):
 
     fake_warning.assert_called_with("\nUnable to check for uncommitted changes. Please ensure you're in a valid git repository.")
 
-    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True)
+    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
 
 def test_jump_operation_has_changes_exit(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch',return_value='master')
-    mocker.patch('pygitgo.commands.jump.get_main_branch',return_value='main')
-    mocker.patch('pygitgo.commands.jump.is_branch_exist',return_value=True)
     
     fake_warning = mocker.patch('pygitgo.commands.jump.warning')
-    fake_success = mocker.patch('pygitgo.commands.jump.success')
     mocker.patch('builtins.input',side_effect=['n'])
     
     fake_run = mocker.patch(
         'pygitgo.commands.jump.run_command',
-        side_effect=['some-changes', 'ok', 'ok']
+        side_effect=['some-changes']
     )
 
     assert check_pytest_system_exit(lambda: jump_operation(['main'])) == 0
 
-    fake_warning.assert_any_call("\nOkay! Leaving your changes here. Jumping without them...\n")
-    fake_success.assert_any_call("\nSuccess! You are now on 'main'.\n")
-    
-    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True)
-    fake_run.assert_any_call(['git', 'checkout', 'main'], loading_msg="Moving you to branch 'main'...")
-    fake_run.assert_any_call(['git', 'pull', 'origin', 'main'], allow_fail=True, loading_msg="Downloading the latest updates from 'main'...")
+    fake_warning.assert_any_call("\nYou cannot switch branches with unsaved changes. Jump canceled.\n")
+    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
 
 def test_jump_operation_save_changes_error(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch',return_value='master')
@@ -87,7 +92,7 @@ def test_jump_operation_save_changes_error(mocker):
     fake_run = mocker.patch(
         'pygitgo.commands.jump.run_command',
         side_effect=lambda *args, **kwargs: (
-            'ok' if args[0] != ["git", "stash", "push", "-m", "GitGo Jump Auto-Stash"] else 
+            'ok' if args[0] != ["git", "stash", "push", "-u", "-m", "GitGo Jump Auto-Stash"] else 
             subprocess.CalledProcessError(1, 'git')
         )
     )
@@ -95,8 +100,8 @@ def test_jump_operation_save_changes_error(mocker):
     assert check_pytest_system_exit(lambda: jump_operation(['main'])) == 1
 
     fake_warning.assert_called_with("\nFailed to save your changes. Please resolve any issues and try again.")
-    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True)
-    fake_run.assert_any_call(["git", "stash", "push", "-m", "GitGo Jump Auto-Stash"], allow_fail=True, loading_msg="Saving your changes before jumping...")
+    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
+    fake_run.assert_any_call(["git", "stash", "push", "-u", "-m", "GitGo Jump Auto-Stash"], allow_fail=True, loading_msg="Saving your changes before jumping...")
 
 def test_jump_operation_no_changes(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch',return_value='master')
@@ -116,7 +121,7 @@ def test_jump_operation_no_changes(mocker):
     assert check_pytest_system_exit(lambda: jump_operation([target_branch])) == 0
 
     fake_success.assert_called_with(f"\nSuccess! You are now on '{target_branch}'.\n")
-    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True)
+    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
     fake_run.assert_any_call(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...")
     fake_run.assert_any_call(['git', 'pull', 'origin', 'main'], allow_fail=True, loading_msg=f"Downloading the latest updates from 'main'...")
 
@@ -145,8 +150,8 @@ def test_jump_operation_branch_not_exist_cancel_operation(mocker):
 
     fake_info.assert_any_call('\nYour changes have been saved. Jumping to the new branch...')
     fake_info.assert_any_call("Exiting without jumping...\n")
-    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True)
-    fake_run.assert_any_call(["git", "stash", "push", "-m", "GitGo Jump Auto-Stash"], allow_fail=True, loading_msg="Saving your changes before jumping...")
+    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
+    fake_run.assert_any_call(["git", "stash", "push", "-u", "-m", "GitGo Jump Auto-Stash"], allow_fail=True, loading_msg="Saving your changes before jumping...")
     fake_run.assert_any_call(["git", "stash", "pop"], loading_msg="Putting your unsaved changes back...")
 
 def test_jump_operation_branch_not_exist_create_branch(mocker):
@@ -178,9 +183,9 @@ def test_jump_operation_branch_not_exist_create_branch(mocker):
     fake_info.assert_called_with('\nYour changes have been saved. Jumping to the new branch...')
     fake_success.assert_any_call(f"\nSuccess! You are now on '{target_branch}'.")
     fake_success.assert_any_call("Your unsaved code was moved here safely!\n")
-    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True)
+    fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
     fake_run.assert_any_call(['git', 'pull', 'origin', 'main'], allow_fail=True, loading_msg=f"Downloading the latest updates from 'main'...")
-    fake_run.assert_any_call(["git", "stash", "push", "-m", "GitGo Jump Auto-Stash"], allow_fail=True, loading_msg="Saving your changes before jumping...")
+    fake_run.assert_any_call(["git", "stash", "push", "-u", "-m", "GitGo Jump Auto-Stash"], allow_fail=True, loading_msg="Saving your changes before jumping...")
     fake_run.assert_any_call(['git', 'stash', 'apply'], allow_fail=True, loading_msg="Unpacking your unsaved changes...")
     fake_run.assert_any_call(["git", "stash", "drop"], allow_fail=True, loading_msg="Cleaning up the temporary stash...")
 
@@ -260,6 +265,7 @@ def test_jump_operation_merge_conflict_stay(mocker):
 
     fake_success = mocker.patch('pygitgo.commands.jump.success')
     fake_warning = mocker.patch('pygitgo.commands.jump.warning')
+    fake_info = mocker.patch('pygitgo.commands.jump.info')
     fake_run = mocker.patch(
         'pygitgo.commands.jump.run_command',
         side_effect=lambda *args, **kwargs: (
@@ -270,5 +276,8 @@ def test_jump_operation_merge_conflict_stay(mocker):
     assert check_pytest_system_exit(lambda: jump_operation(['feature'])) == 0
 
     fake_success.assert_any_call("\nOkay! You are on the new branch with your code.")
-    fake_warning.assert_any_call("Please open your code editor RIGHT NOW to fix the conflicts!\n")
-    fake_run.assert_any_call(["git", "stash", "drop"], allow_fail=True, loading_msg="Cleaning up the temporary stash...")
+    fake_warning.assert_any_call("Please open your code editor RIGHT NOW to fix the conflicts!")
+    fake_info.assert_any_call("Your stash backup is still saved. Run 'gitgo state list' to see it.\n")
+
+    with pytest.raises(AssertionError):
+        fake_run.assert_any_call(["git", "stash", "drop"], allow_fail=True, loading_msg="Cleaning up the temporary stash...")


### PR DESCRIPTION
## Problem
- `get_main_branch` was reading the full output of `git remote show origin` instead of just the branch name, which caused `git pull` to fail
- `get_current_branch` returns empty when git is in detached HEAD state, causing the tool to try creating a branch that already exists and crash

## Fix
- `get_main_branch` now only reads the first line of the output using `.splitlines()[0]`
- `get_current_branch` now falls back to the commit hash via `git rev-parse` when no branch name is available