### PR TITLE
feat: migrate CLI to argparse and add config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ GitGo provides a CLI environment designed for faster and simpler Git workflows. 
 - **Simplified Git Operations:** Replaces chained commands with single intuitive commands for linking, pushing, and stashing.
 - **Smart Branch Hopping:** Safely traverse branches with `jump`. Auto-stashes messy code and prevents merge conflict disasters with a Try-And-Revert safety engine.
 - **State Management:** A human-readable interface over `git stash`. States are named and listed by index so you never have to remember cryptic stash references.
+- **Custom Defaults:** Save your preferred branch name and commit message locally so you never have to type them again.
 - **SSH Auto-Setup:** Generates an SSH key, adds it to `ssh-agent`, and opens your GitHub settings automatically.
 - **HTTPS to SSH Conversion:** Silently converts the remote to SSH before pushing if your SSH is configured.
 - **Termux Compatibility:** Works natively on Android natively handling common issues like dubious ownership errors.
@@ -130,6 +131,14 @@ gitgo state list
 gitgo state load 1
 ```
 
+### 6. Custom Defaults
+Save your preferred settings so you don't have to provide them every time.
+```bash
+gitgo config set default-branch develop
+gitgo config set default-message "WIP: updates"
+gitgo config get default-branch
+```
+
 ---
 
 ## Command Reference
@@ -142,6 +151,9 @@ Stages all changes, commits, and pushes in one command.
 gitgo push [branch] [message]
 gitgo push -n [branch] [message]   # create new branch first
 ```
+
+> [!TIP]
+> Use `gitgo push -h` to see all available flags and examples.
 
 | Flag | Description |
 |------|-------------|
@@ -186,10 +198,25 @@ gitgo user login        # generate SSH key and configure Git identity
 gitgo user logout       # remove SSH keys and Git identity config
 ```
 
+### `gitgo config`
+
+Manage your GitGo defaults.
+
+```bash
+gitgo config set <key> <value>
+gitgo config get <key>
+```
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `default-branch` | The branch used for push/link | `main` |
+| `default-message` | The commit message used for push | `New Project Update` |
+
 ### Global Flags
 
 ```bash
-gitgo -h        # help
+gitgo help      # show complete manual
+gitgo <cmd> -h  # show help for a specific command
 gitgo -v        # version
 gitgo -r        # verify GitGo is ready
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.1.1"
+version = "1.2.0"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/commands/git_operations.py
+++ b/src/pygitgo/commands/git_operations.py
@@ -1,11 +1,10 @@
 from pygitgo.auth.ssh_utils import convert_https_to_ssh, is_ssh_url, check_connection
-from pygitgo.utils.executor import run_command
 from pygitgo.utils.colors import info, success, warning, error
+from pygitgo.utils.executor import run_command
+from pygitgo.utils.config import get_config
 import subprocess
 import sys
 import os
-
-DEFAULT_MAIN_BRANCH = "main"
 
 
 def get_current_branch():
@@ -16,10 +15,11 @@ def get_current_branch():
 
 def get_main_branch():
     main_branch = run_command(['git', 'remote', 'show', 'origin'], allow_fail=True)
+    default_main_branch = get_config("default-branch", "main")
     if isinstance(main_branch, subprocess.CalledProcessError):
-        return DEFAULT_MAIN_BRANCH
+        return default_main_branch
     
-    return main_branch.split("HEAD branch:")[-1].strip().splitlines()[0].strip() if "HEAD branch:" in main_branch else DEFAULT_MAIN_BRANCH
+    return main_branch.split("HEAD branch:")[-1].strip().splitlines()[0].strip() if "HEAD branch:" in main_branch else default_main_branch
 
 def is_branch_exist(branch):
     return bool(run_command(["git", "branch", "-r", "--list", f"*/{branch}"])) or bool(run_command(["git", "branch", "--list", branch]))
@@ -50,10 +50,12 @@ def git_init():
         warning("Already a git repository! Skipping init...")
         return True
     
-    result = run_command(["git", "init", "-b", DEFAULT_MAIN_BRANCH], allow_fail=True, loading_msg="Initializing git repository...")
+    default_main_branch = get_config("default-branch", "main")
+
+    result = run_command(["git", "init", "-b", default_main_branch], allow_fail=True, loading_msg="Initializing git repository...")
     if isinstance(result, subprocess.CalledProcessError):
         run_command(["git", "init"], loading_msg="Initializing git repository...")
-        run_command(["git", "checkout", "-b", DEFAULT_MAIN_BRANCH], allow_fail=True)
+        run_command(["git", "checkout", "-b", default_main_branch], allow_fail=True)
 
     success("Git repository initialized.")
     return True

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -7,9 +7,6 @@ from pygitgo.utils.colors import warning, info, success, error
 import subprocess
 import sys
 
-def jump_operations_help():
-    warning("\nUsage: gitgo jump <branch>\n")
-    warning("branch: The name of the branch to jump to.\n")
 
 def undo_jump_operation(original_branch, stashed_code, created_branch=None):
     if created_branch:
@@ -25,12 +22,10 @@ def undo_jump_operation(original_branch, stashed_code, created_branch=None):
     success(f"\nCanceled safely!")
     success(f"You are back on your original branch '{original_branch}', and your code is totally safe.\n")
 
-def jump_operation(arguments):  
-    if len(arguments) == 0 or arguments[0] in ("-h", "--help", "help"):
-        jump_operations_help()
-        sys.exit(0)
+def jump_operation(args):  
 
-    target_branch = arguments[0]
+
+    target_branch = args.branch
 
     original_branch = get_current_branch().strip()
     

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -3,6 +3,13 @@ from pygitgo.utils.colors import info, highlight, error, warning, success
 import sys
 
 
+ALIASES = {
+    "-l": "list",
+    "-s": "save",
+    "-o": "load",
+    "-d": "delete"
+}
+
 def all_save_state():
     output = run_command([
         "git", "stash", "list",
@@ -88,42 +95,21 @@ def ask_state_id(save_states):
     return state_id
 
 
-def state_list(arguments):
-    if len(arguments) > 1:
-        if arguments[1] in ("-h", "--help", "help"):
-            warning("\nUsage: gitgo state list\n")
-            warning("list: Display all saved states (Alias: -l)\n")
-            sys.exit(0)
-        error("\nToo many arguments for list operation!\n")
-        sys.exit(1)
-
+def state_list():
     display_save_states()
 
 
-def load_state(arguments):
-    if len(arguments) > 2:
-        error("\nToo many arguments for load operation!\n")
-        sys.exit(1)
-
+def load_state(state_id=None):
     save_states = all_save_state()
     proceed = False
-    state_id = None
 
-    if len(arguments) == 2:
-        if arguments[1] in ("-h", "--help", "help"):
-            print("\nLoad a previously saved working state.\n")
-            warning("\nUsage:\n")
-            print("  gitgo state load <id>   # Load a specific state by ID")
-            print("  gitgo state load        # Show all saved states and prompt for selection")
-            print("  gitgo state -o <id>     # Alias\n")
-            sys.exit(0)
-        elif arguments[1].isdigit():
-            state_id = arguments[1]
+    if state_id:
+        if state_id.isdigit():
             proceed = validate_state_id(state_id, save_states)
             if not proceed:
                 sys.exit(1)
         else:
-            error(f"\nInvalid argument '{arguments[1]}' for load operation. Expected a state ID.\n")
+            error(f"\nInvalid argument '{state_id}' for load operation. Expected a state ID.\n")
             sys.exit(1)
     
     if not proceed:
@@ -134,46 +120,20 @@ def load_state(arguments):
     success(f"\nState '{save_states[int(state_id) - 1]['message']}' loaded successfully.\n")
 
 
-def save_state(arguments):
-    if len(arguments) > 2:
-        error("\nToo many arguments for save operation!\n")
-        sys.exit(1)
-    elif len(arguments) < 2:
+def save_state(state_name=None):
+    if not state_name:
         state_name = "Auto-Save"
-    
-    if len(arguments) == 2:
-        if arguments[1] in ("-h", "--help", "help"):
-            print("\nSave the current working state with an optional name.\n")
-            warning("\nUsage:\n")
-            print("  gitgo state save <name>   # Save with a specific name")
-            print("  gitgo state save          # Save with default name 'Auto-Save'")
-            print("  gitgo state -s <name>     # Alias\n")
-            sys.exit(0)
-            
-        state_name = arguments[1]
 
     run_command(["git", "stash", "push", "-m", state_name])
 
     success(f"\nState '{state_name}' saved successfully.\n")
 
 
-def delete_state(arguments):
-    if len(arguments) > 2:
-        error("\nToo many arguments for delete operation!\n")
-        sys.exit(1)
-    elif len(arguments) < 2:
+def delete_state(identifier=None):
+    if not identifier:
         state_id = ask_state_id(all_save_state())
     else:
-        if arguments[1] in ("-h", "--help", "help"):
-            print("\nDelete one or all saved working states.\n")
-            warning("\nUsage:\n")
-            print("  gitgo state delete <id>   # Delete a specific state by ID")
-            print("  gitgo state delete -a     # Delete all saved states")
-            print("  gitgo state -d <id>       # Alias\n")
-            print("  gitgo state -d <id> -a    # Alias for delete all\n")
-            sys.exit(0)
-        
-        elif arguments[1] == '-a':
+        if identifier == '-a':
             confirm = input("\nAre you sure you want to delete all saved states? (y/n): ").strip().lower()
             if confirm.lower() == 'y':
                 run_command(["git", "stash", "clear"])
@@ -183,11 +143,11 @@ def delete_state(arguments):
                 warning("\nDelete operation cancelled by user.\n")
                 sys.exit(0)
         
-        elif not arguments[1].isdigit():
+        elif not identifier.isdigit():
             error("\nInvalid input. Please enter a valid state ID.\n")
             sys.exit(1)
 
-        state_id = arguments[1]
+        state_id = identifier
         if not validate_state_id(state_id, all_save_state()):
             sys.exit(1)
     
@@ -195,30 +155,20 @@ def delete_state(arguments):
     success(f"\nState with ID '{state_id}' deleted successfully.\n")
 
 
-def state_operations_help():
-    warning("\nState Operations Help:\n")
-    print("  list, -l      Display all saved states.")
-    print("  load, -o      Load a previously saved working state.")
-    print("  save, -s      Save the current working state with a given name.")
-    print("  delete, -d    Delete a previously saved working state.\n")
-    info("Use 'gitgo state <operation> --help' for more information on a specific operation.\n")
 
 
-def state_operations(arguments):
-    if len(arguments) == 0 or arguments[0] in ("-h", "--help", "help"):
-        state_operations_help()
-        sys.exit(0)
+def state_operations(args):
+    action = ALIASES.get(args.action, args.action)
+    identifier = getattr(args, "identifier", None)
 
-    type_of_operation = arguments[0].lower()
-    if type_of_operation in ["list", "-l"]:
-        state_list(arguments)
-    elif type_of_operation in ["load", "-o"]:
-        load_state(arguments)
-    elif type_of_operation in ["save", "-s"]:
-        save_state(arguments)
-    elif type_of_operation in ["delete", "-d"]:
-        delete_state(arguments)
+    if action == "list":
+        state_list()
+    elif action == "save":
+        save_state(identifier)
+    elif action == "load":
+        load_state(identifier)
+    elif action == "delete":
+        delete_state(identifier)
     else:
-        error(f"\nUnknown state operation: {type_of_operation}\n")
-        state_operations_help()
+        error(f"\nUnknown state operation: {action}\n")
         sys.exit(1)

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -179,8 +179,8 @@ def main():
         description="GitGo CLI - Your Fast Git Companion",
         epilog="Use 'gitgo <command> -h' for help on a specific command."
     )
-
-    parser.add_argument("-v", "--version", action="version", version=f"GitGo {get_version()}")
+    
+    parser.add_argument("-v", "-V", "--version", action="version", version=f"GitGo {get_version()}")
     parser.add_argument("-r", "--ready", action="store_true", help="Check tool readiness")
 
     subparsers = parser.add_subparsers(title="Commands", dest="command")

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -5,22 +5,21 @@ from pygitgo.commands.git_operations import (
     git_push, handle_rebase, get_current_branch, is_branch_exist
 )
 from pygitgo.utils.colors import info, success, warning, error, highlight
+from pygitgo.utils.config import get_config, config_operation
+from pygitgo.utils.setup import ensure_first_run_setup
 from pygitgo.commands.state import state_operations
 from pygitgo.commands.jump import jump_operation
 from pygitgo.utils.executor import run_command
 from pygitgo.auth.manager import login, logout
-from pygitgo.exceptions import GitGoError
 from pygitgo.auth.account import get_user
+from pygitgo.exceptions import GitGoError
 import subprocess
-import shutil
+import argparse
 import sys
 import re
 
 
-GITGO_OPERATIONS = ["push", "link", "state", "user", "jump"]
-HELP_COMMANDS = ["help", "--help", "-h"]
-DEFAULT_COMMIT_MSG = "New Project Update"
-DEFAULT_MAIN_BRANCH = "main"
+
 
 
 def validate_repo_url(url):
@@ -32,28 +31,8 @@ def validate_repo_url(url):
     return any(re.match(p, url.strip()) for p in patterns)
 
 
-def check_git_installed():
-    """Verify that Git is installed and available on PATH."""
-    if not shutil.which("git"):
-        error("\nGit is not installed or not found on your PATH!")
-        info("Install Git from: https://git-scm.com/downloads")
-        info("After installing, restart your terminal and try again.\n")
-        sys.exit(1)
-
-
-def link_operation(arguments):
-    if len(arguments) < 2:
-        error("\nGitHub repository URL required!")
-        warning("Usage: gitgo link <github_repo_url> [commit_message]\n")
-        sys.exit(1)
-    
-    if arguments[1] in HELP_COMMANDS:
-        warning("\nUsage: gitgo link <github_repo_url> [commit_message]\n")
-        warning("github_repo_url: The GitHub repository URL to link")
-        warning("commit_message: Custom commit message (default: 'Initial commit')\n")
-        sys.exit(0)
-    
-    repo_url = arguments[1]
+def link_operation(args):
+    repo_url = args.url
 
     if not validate_repo_url(repo_url):
         error("\nInvalid repository URL!")
@@ -61,7 +40,7 @@ def link_operation(arguments):
         warning("             or: git@github.com:username/repo.git\n")
         sys.exit(1)
 
-    commit_message = arguments[2] if len(arguments) > 2 else "Initial commit"
+    commit_message = args.message
     
     info("\nINITIATING LINK OPERATION...")
     info(f"Target: {repo_url}\n")
@@ -83,26 +62,28 @@ def link_operation(arguments):
         return
     
     current_branch = get_current_branch()
-    if current_branch.strip() != DEFAULT_MAIN_BRANCH:
-        run_command(["git", "branch", "-m", DEFAULT_MAIN_BRANCH], loading_msg=f"Renaming branch '{current_branch.strip()}' to '{DEFAULT_MAIN_BRANCH}'...")
-        current_branch = DEFAULT_MAIN_BRANCH
+    main_branch = get_config("default-branch", "main")
     
-    remote_refs = run_command(["git", "ls-remote", "--heads", "origin", DEFAULT_MAIN_BRANCH], allow_fail=True, loading_msg="Checking remote branches...")
+    if current_branch.strip() != main_branch:
+        run_command(["git", "branch", "-m", main_branch], loading_msg=f"Renaming branch '{current_branch.strip()}' to '{main_branch}'...")
+        current_branch = main_branch
+    
+    remote_refs = run_command(["git", "ls-remote", "--heads", "origin", main_branch], allow_fail=True, loading_msg="Checking remote branches...")
     if not isinstance(remote_refs, subprocess.CalledProcessError) and remote_refs.strip():
         pull_result = run_command(
-            ["git", "pull", "origin", DEFAULT_MAIN_BRANCH, "--allow-unrelated-histories", "--no-edit"],
+            ["git", "pull", "origin", main_branch, "--allow-unrelated-histories", "--no-edit"],
             allow_fail=True, loading_msg="Pulling and merging remote content..."
         )
         if isinstance(pull_result, subprocess.CalledProcessError):
             error("Failed to merge remote content. You may need to resolve conflicts manually.")
-            warning("Run: git pull origin main --allow-unrelated-histories")
-            warning("Then: gitgo push main 'your message'\n")
+            warning(f"Run: git pull origin {main_branch} --allow-unrelated-histories")
+            warning(f"Then: gitgo push {main_branch} 'your message'\n")
             return
         success("Remote content merged successfully.")
     
     print("\n" + ("=" * 90))
     success("LINK OPERATION COMPLETE! REPOSITORY LOCKED AND LOADED!")
-    success(f"Ready to push with: gitgo push {DEFAULT_MAIN_BRANCH} 'your message'")
+    success(f"Ready to push with: gitgo push {main_branch} 'your message'")
     info("AWAITING FURTHER ORDERS...\n")
 
     user_choice = input(f"\nDo you want to push now? (y/n): ").lower()
@@ -115,45 +96,24 @@ def link_operation(arguments):
     success("MISSION COMPLETE — REPOSITORY INITIALIZED AND PUSHED!\nAWAITING FOR YOUR NEXT ORDERS.\n\n")
     
 
-def push_operation(arguments):
-    if len(arguments) > 1 and arguments[1] in HELP_COMMANDS:
-        warning("\nUsage: gitgo push [branch] [commit_message]\n")
-        warning("branch: The branch to push to (default: main)")
-        warning("commit_message: The commit message (default: empty string)\n")
-        sys.exit(0)
-    
-    branch = None
-    message = None
+def push_operation(args):
+    branch = args.branch
+    message = args.message
 
-    if len(arguments) > 1 and arguments[1] in ["-n", "new"]:
-        if len(arguments) < 3:
-            error("\nBranch name required for new branch creation!\n")
+    if args.new:
+        if not branch:
+            error("\nBranch name required when using --new flag!\n")
             sys.exit(1)
-        elif len(arguments) < 4:
-            message = DEFAULT_COMMIT_MSG
-        elif len(arguments) > 4:
-            error("\nToo many arguments for new branch creation!\n")
-            sys.exit(1)
-
-        branch = arguments[2]
         git_new_branch(branch)
     else:
-        if len(arguments) < 2:
+        if branch and not message and not is_branch_exist(branch):
+            message = branch
             branch = get_current_branch()
-            message = DEFAULT_COMMIT_MSG
-        elif len(arguments) < 3:
-            if is_branch_exist(arguments[1]):
-                message = DEFAULT_COMMIT_MSG
-            else:
-                branch = get_current_branch()
-                message = arguments[1]
-        elif len(arguments) > 3:
-            error("\nToo many arguments!\n")
-            sys.exit(1)
+        elif not branch:
+            branch = get_current_branch()
 
-        branch = branch if branch else arguments[1]
-    
-    message = message if message else arguments[-1]
+    if not message:
+        message = get_config("default-message", "New Project Update")
 
     commit_made = git_commit(message)
     
@@ -178,12 +138,6 @@ def push_operation(arguments):
     success("MISSION COMPLETE — NO CASUALTIES. ALL TARGETS NEUTRALIZED.\nAWAITING FOR YOUR NEXT ORDERS.\n\n")
 
 
-def validate_operation(operation):
-    if operation not in GITGO_OPERATIONS:
-        error(f"\nInvalid operation '{operation}'!")
-        warning(f"Supported operations are: {', '.join(GITGO_OPERATIONS)}\n")
-        sys.exit(1)
-
 def display_current_user():
     username, email = get_user()
     if username and email:
@@ -196,38 +150,19 @@ def display_current_user():
         info("Run 'gitgo user login'\n")
 
 
-def user_management(operation):
-    if not operation:
-        display_current_user()
-        exit(0)
-    if len(operation) > 1:
-        if operation[1] in HELP_COMMANDS:
-            if operation[0] == "login":
-                warning("\nUsage: gitgo user login\n")
-                warning("login: Sets up your Git user identity (name and email) for commits.\n")
-            elif operation[0] == "logout":
-                warning("\nUsage: gitgo user logout\n")
-                warning("logout: Removes your Git user identity configuration.\n")
-            else:
-                warning("\nUsage: gitgo user <login | logout>\n")
-                warning("login: Configure your Git user identity.")
-                warning("logout: Remove your Git user identity configuration.\n")
-            sys.exit(0)
-        else:
-            error("\nToo many arguments for user management!\n")
-            sys.exit(1)
+def user_management(args):
+    action = args.action if hasattr(args, 'action') else None
 
-    if operation[0] == "login":
-        login()
-    elif operation[0] == "logout":
-        logout()
-    elif operation[0] in HELP_COMMANDS:
-        warning("\nUsage: gitgo user <login | logout>\n")
-        warning("login: Configure your Git user identity.")
-        warning("logout: Remove your Git user identity configuration.\n")
+    if not action:
+        display_current_user()
         sys.exit(0)
+    
+    if action == 'login':
+        login()
+    elif action == 'logout':
+        logout()
     else:
-        error(f"\nInvalid user operation '{operation[0]}'!\n")
+        error(f"\nInvalid user operation '{action}'!\n")
         sys.exit(1)
 
 
@@ -238,86 +173,113 @@ def get_version():
     except Exception:
         return "dev"
 
-def display_help():
-    print("")
-    highlight("       GitGo CLI - Your Fast Git Companion")
-    warning("=" * 60)
-    info("Usage: gitgo <command> [arguments]\n")
-    
-    warning("CORE COMMANDS:")
-    success("  push")
-    print("      gitgo push [branch] [message]       Push branch to remote")
-    print("      gitgo push -n <branch> [msg]        Create new branch & push\n")
-    
-    success("  link")
-    print("      gitgo link <url> [message]          Init, commit, and link to repo\n")
-    
-    success("  jump")
-    print("      gitgo jump <branch>                 Safely switch branches with try-and-revert\n")
-    
-    warning("STATE MANAGEMENT:")
-    success("  state")
-    print("      gitgo state list | -l               List all saved states (stashes)")
-    print("      gitgo state save | -s [name]        Save the current working state")
-    print("      gitgo state load | -o [id]          Load a previously saved state")
-    print("      gitgo state delete | -d [id] | -a   Delete a specific or all states\n")
-    
-    warning("USER CONFIGURATION:")
-    success("  user")
-    print("      gitgo user login                    Setup Git username and email")
-    print("      gitgo user logout                   Remove Git user configuration\n")
-    
-    
-    warning("GLOBAL FLAGS:")
-    print("  -h, --help, help                        Show this complete help manual")
-    print("  -v, version                             Show GitGo version")
-    print("  -r, ready                               Check tool readiness\n")
-    sys.exit(0)
-
 def main():
-    if len(sys.argv) < 2:
-        error("\nInvalid arguments!\n")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        prog='gitgo',
+        description="GitGo CLI - Your Fast Git Companion",
+        epilog="Use 'gitgo <command> -h' for help on a specific command."
+    )
 
-    arguments = sys.argv[1:]
+    parser.add_argument("-v", "--version", action="version", version=f"GitGo {get_version()}")
+    parser.add_argument("-r", "--ready", action="store_true", help="Check tool readiness")
 
-    type_of_operation = arguments[0].lower()
+    subparsers = parser.add_subparsers(title="Commands", dest="command")
+    subparsers.required = False
 
-    if type_of_operation in ["-r", "ready"]:
+    jump_parser = subparsers.add_parser("jump", help="Safely switch branches with try-and-revert")
+    jump_parser.add_argument("branch", help="The name of the branch to jump to")
+
+    link_parser = subparsers.add_parser("link", help="Init, commit, and link to a remote repo")
+    link_parser.add_argument("url", help="The GitHub repository URL to link")
+    link_parser.add_argument("message", nargs="?", default="Initial commit", help="Custom commit message")
+
+    push_parser = subparsers.add_parser(
+        "push",
+        help="Commit and push branch to remote",
+        epilog=(
+            "Examples:\n"
+            "  gitgo push                        Push current branch with default message\n"
+            "  gitgo push main 'fix auth bug'    Push to main with a custom message\n"
+            "  gitgo push 'fix auth bug'         Push current branch with a custom message\n"
+            "  gitgo push -n feature/login 'add login'   Create new branch and push"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    push_parser.add_argument("-n", "--new", action="store_true", help="Create a new branch before pushing")
+    push_parser.add_argument("branch", nargs="?", default=None, help="Branch to push to (default: current branch)")
+    push_parser.add_argument("message", nargs="?", default=None, help="Commit message")
+
+    state_parser = subparsers.add_parser(
+        "state",
+        help="Manage saved working states (stashes)",
+        epilog=(
+            "Examples:\n"
+            "  gitgo state list                  Show all saved states\n"
+            "  gitgo state save 'halfway done'   Save current work with a name\n"
+            "  gitgo state load 1                Restore state by ID\n"
+            "  gitgo state delete 1              Delete a specific state\n"
+            "  gitgo state delete -a             Delete all saved states"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    state_parser.add_argument(
+        "action",
+        choices=["list", "save", "load", "delete", "-l", "-s", "-o", "-d"],
+        metavar="action",
+        help="list, save, load, delete  (aliases: -l, -s, -o, -d)"
+    )
+    state_parser.add_argument(
+        "identifier",
+        nargs="?",
+        default=None,
+        help="Optional name or ID"
+    )
+    
+    user_parser = subparsers.add_parser("user", help="Manage Git user identity")
+    user_parser.add_argument("action", nargs="?", choices=["login", "logout"], default=None, help="login or logout")
+
+    config_parser = subparsers.add_parser("config",
+        help="Manage GitGo default settings",
+        epilog=(
+            "Examples:\n"
+            "  gitgo config set default-branch master\n"
+            "  gitgo config set default-message 'WIP'\n"
+            "  gitgo config get default-branch"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    config_parser.add_argument("action", choices=["set", "get"], help="Action to perform")
+    config_parser.add_argument("key", choices=["default-branch", "default-message"], help="The setting to change")
+    config_parser.add_argument("value", nargs="?", help="The new value (required for 'set')")
+
+    args = parser.parse_args()
+
+    if args.ready:
         info("\nALL UNITS ONLINE. GitGo STANDING BY. AWAITING COMMANDS...\n")
         sys.exit(0)
 
-    if type_of_operation in ["-v", "version"]:
-        highlight(f"\nGitGo Version {get_version()}\n")
+    if not args.command:
+        parser.print_help()
         sys.exit(0)
 
-    if type_of_operation in HELP_COMMANDS:
-        display_help()
-
-    check_git_installed()
-
-    validate_operation(type_of_operation)
-
-    ensure_github_known_host()
+    ensure_first_run_setup()
 
     try:
-        if type_of_operation == GITGO_OPERATIONS[0]:
-            push_operation(arguments)
-        elif type_of_operation == GITGO_OPERATIONS[1]:
-            link_operation(arguments)
-        elif type_of_operation == GITGO_OPERATIONS[2]:
-            state_operations(arguments[1:])
-        elif type_of_operation == GITGO_OPERATIONS[3]:
-            user_management(arguments[1:])
-        elif type_of_operation == GITGO_OPERATIONS[4]:
-            jump_operation(arguments[1:])
-        else:
-            error(f"\nInsufficient arguments for {type_of_operation} operation!\n")
-            sys.exit(1)
+        if args.command == "jump":
+            jump_operation(args)
+        elif args.command == "link":
+            link_operation(args)
+        elif args.command == "push":
+            push_operation(args)
+        elif args.command == "state":
+            state_operations(args)
+        elif args.command == "user":
+            user_management(args)
+        elif args.command == "config":
+            config_operation(args)
     except GitGoError as e:
         error(f"\n{e}\n")
         sys.exit(1)
-
 
 if __name__ == "__main__":
     main()

--- a/src/pygitgo/utils/config.py
+++ b/src/pygitgo/utils/config.py
@@ -1,0 +1,54 @@
+from pygitgo.utils.executor import run_command
+from pygitgo.utils.colors import *
+import subprocess
+
+
+def get_config(key, fallback_value):
+
+    config_key = f"gitgo.{key}"
+
+    result = run_command(['git', 'config', '--global', config_key], allow_fail=True)                                                                                                                     
+
+    if not result or isinstance(result, subprocess.CalledProcessError):
+        return fallback_value
+
+    return result.strip()
+
+
+def set_config(key, value):
+
+    config_key = f"gitgo.{key}"
+
+    result = run_command(['git', 'config', '--global', config_key, value], allow_fail=True)
+    
+    if isinstance(result, subprocess.CalledProcessError):
+        error(f"\nFailed to save configuration for '{key}'.")
+        return False 
+
+    success(f"\nConfiguration saved: {key} = '{value}'")
+    return True
+
+
+def config_operation(args):
+
+    key = args.key
+    action = args.action
+    value = getattr(args, 'value', None)
+
+    VALID_KEYS = ["default-branch", "default-message"]
+    if key not in VALID_KEYS:
+        error(f"\nInvalid configuration key: '{key}'")
+        warning(f"Valid keys are: {', '.join(VALID_KEYS)}\n")
+        return
+
+    if action == 'set':
+        if not value:
+            error("\nYou must provide a value to set!\n")
+            return
+        set_config(key, value)
+    elif action == 'get':
+        current_value = get_config(key, None)
+        if current_value:
+            info(f"\n{key} is currently set to: '{current_value}'\n")
+        else:
+            warning(f"\n{key} is not currently set.\n")

--- a/src/pygitgo/utils/setup.py
+++ b/src/pygitgo/utils/setup.py
@@ -1,0 +1,26 @@
+from pygitgo.auth.ssh_utils import ensure_github_known_host
+from pygitgo.utils.config import get_config, set_config
+from pygitgo.utils.colors import error, info
+import shutil
+import sys
+
+
+def check_git_installed():
+    """Verify that Git is installed and available on PATH."""
+    if not shutil.which("git"):
+        error("\nGit is not installed or not found on your PATH!")
+        info("Install Git from: https://git-scm.com/downloads")
+        info("After installing, restart your terminal and try again.\n")
+        sys.exit(1)
+
+
+def ensure_first_run_setup():
+    check_git_installed()
+
+    is_initialized = get_config("initialized", fallback_value="false")
+
+    if not is_initialized:
+        info("\nInitializing GitGo network settings for the first time... please wait.")
+        ensure_github_known_host()
+
+        set_config("initialized", "true")

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -55,6 +55,7 @@ def test_git_init_already_initialized(mocker):
 
 def test_git_init_success(mocker):
     mocker.patch('os.path.isdir', return_value=False)
+    mocker.patch('pygitgo.commands.git_operations.get_config', return_value='main')
     fake_success = mocker.patch('pygitgo.commands.git_operations.success')
     fake_run = mocker.patch('pygitgo.commands.git_operations.run_command', return_value='ok')
 
@@ -70,6 +71,7 @@ def test_git_init_success(mocker):
 
 def test_git_init_fallback(mocker):
     mocker.patch('os.path.isdir', return_value=False)
+    mocker.patch('pygitgo.commands.git_operations.get_config', return_value='main')
     fake_success = mocker.patch('pygitgo.commands.git_operations.success')
     
     fake_run = mocker.patch(

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -1,6 +1,11 @@
 from pygitgo.commands.jump import undo_jump_operation, jump_operation
+from argparse import Namespace
 import subprocess
 import pytest
+
+def make_args(branch):
+    """Helper to create an argparse-like Namespace for jump_operation."""
+    return Namespace(branch=branch)
 
 def check_pytest_system_exit(function):
     with pytest.raises(SystemExit) as exc_info:
@@ -34,14 +39,6 @@ def test_undo_jump_operation_deletes_ghost_branch(mocker):
     fake_run.assert_any_call(["git", "branch", "-D", "ghost-branch"], allow_fail=True, loading_msg="Removing the empty branch 'ghost-branch'...")
     fake_run.assert_any_call(["git", "stash", "pop"], loading_msg="Restoring your unsaved changes...")
 
-def test_jump_operation_help(mocker):
-    fake_run = mocker.patch(
-        'pygitgo.commands.jump.jump_operations_help', 
-        return_value=''
-    )
-    
-    assert check_pytest_system_exit(lambda: jump_operation(['-h'])) == 0
-
 def test_jump_operation_same_branch(mocker):
     main_branch = 'main'
     fake_run = mocker.patch(
@@ -50,7 +47,7 @@ def test_jump_operation_same_branch(mocker):
     )
     fake_warning = mocker.patch('pygitgo.commands.jump.warning')
 
-    assert check_pytest_system_exit(lambda: jump_operation([main_branch])) == 0
+    assert check_pytest_system_exit(lambda: jump_operation(make_args(main_branch))) == 0
 
     fake_warning.assert_called_with(f"\nYou are already on branch '{main_branch}'.\n")
 
@@ -63,7 +60,7 @@ def test_jump_operation_not_valid_repo(mocker):
         return_value=subprocess.CalledProcessError(1, 'git')
     )
     
-    assert check_pytest_system_exit(lambda: jump_operation(['main'])) == 1
+    assert check_pytest_system_exit(lambda: jump_operation(make_args('main'))) == 1
 
     fake_warning.assert_called_with("\nUnable to check for uncommitted changes. Please ensure you're in a valid git repository.")
 
@@ -80,7 +77,7 @@ def test_jump_operation_has_changes_exit(mocker):
         side_effect=['some-changes']
     )
 
-    assert check_pytest_system_exit(lambda: jump_operation(['main'])) == 0
+    assert check_pytest_system_exit(lambda: jump_operation(make_args('main'))) == 0
 
     fake_warning.assert_any_call("\nYou cannot switch branches with unsaved changes. Jump canceled.\n")
     fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
@@ -97,7 +94,7 @@ def test_jump_operation_save_changes_error(mocker):
         )
     )
 
-    assert check_pytest_system_exit(lambda: jump_operation(['main'])) == 1
+    assert check_pytest_system_exit(lambda: jump_operation(make_args('main'))) == 1
 
     fake_warning.assert_called_with("\nFailed to save your changes. Please resolve any issues and try again.")
     fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
@@ -118,7 +115,7 @@ def test_jump_operation_no_changes(mocker):
 
     target_branch = 'feature'
     
-    assert check_pytest_system_exit(lambda: jump_operation([target_branch])) == 0
+    assert check_pytest_system_exit(lambda: jump_operation(make_args(target_branch))) == 0
 
     fake_success.assert_called_with(f"\nSuccess! You are now on '{target_branch}'.\n")
     fake_run.assert_any_call(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
@@ -146,7 +143,7 @@ def test_jump_operation_branch_not_exist_cancel_operation(mocker):
 
     target_branch = 'feature'
     
-    assert check_pytest_system_exit(lambda: jump_operation([target_branch])) == 0
+    assert check_pytest_system_exit(lambda: jump_operation(make_args(target_branch))) == 0
 
     fake_info.assert_any_call('\nYour changes have been saved. Jumping to the new branch...')
     fake_info.assert_any_call("Exiting without jumping...\n")
@@ -178,7 +175,7 @@ def test_jump_operation_branch_not_exist_create_branch(mocker):
 
     target_branch = 'feature'
     
-    assert check_pytest_system_exit(lambda: jump_operation([target_branch])) == 0
+    assert check_pytest_system_exit(lambda: jump_operation(make_args(target_branch))) == 0
 
     fake_info.assert_called_with('\nYour changes have been saved. Jumping to the new branch...')
     fake_success.assert_any_call(f"\nSuccess! You are now on '{target_branch}'.")
@@ -207,7 +204,7 @@ def test_jump_operation_sync_fail_cancel(mocker):
         )
     )
 
-    assert check_pytest_system_exit(lambda: jump_operation(['feature'])) == 1
+    assert check_pytest_system_exit(lambda: jump_operation(make_args('feature'))) == 1
 
     fake_warning.assert_any_call("\nFailed to pull updates from 'main'. Make sure you have internet or the remote branch exists.")
 
@@ -228,7 +225,7 @@ def test_jump_operation_sync_fail_stay(mocker):
         )
     )
 
-    assert check_pytest_system_exit(lambda: jump_operation(['feature'])) == 0
+    assert check_pytest_system_exit(lambda: jump_operation(make_args('feature'))) == 0
 
     fake_success.assert_any_call("\nOkay! You are on the new branch, but without the latest updates from 'main'.")
 
@@ -250,7 +247,7 @@ def test_jump_operation_merge_conflict_cancel(mocker):
         )
     )
 
-    assert check_pytest_system_exit(lambda: jump_operation(['feature'])) == 0
+    assert check_pytest_system_exit(lambda: jump_operation(make_args('feature'))) == 0
 
     fake_error.assert_any_call("\nSTOP! There is a 'Merge Conflict'.")
 
@@ -273,7 +270,7 @@ def test_jump_operation_merge_conflict_stay(mocker):
         )
     )
 
-    assert check_pytest_system_exit(lambda: jump_operation(['feature'])) == 0
+    assert check_pytest_system_exit(lambda: jump_operation(make_args('feature'))) == 0
 
     fake_success.assert_any_call("\nOkay! You are on the new branch with your code.")
     fake_warning.assert_any_call("Please open your code editor RIGHT NOW to fix the conflicts!")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -107,24 +107,6 @@ def test_all_save_state_malformed_line(mocker):
         "--pretty=%gd||%cd||%s"
     ])
 
-def test_load_state_too_many_args(mocker):
-    fake_error = mocker.patch("pygitgo.commands.state.error")
-
-    with pytest.raises(SystemExit) as exc_info:
-        load_state(["load", "1", "extra"])
-
-    assert exc_info.value.code == 1
-    fake_error.assert_called_once_with("\nToo many arguments for load operation!\n")
-
-def test_load_state_help(mocker):
-    mocker.patch("pygitgo.commands.state.all_save_state", return_value=[])
-    fake_warning = mocker.patch("pygitgo.commands.state.warning")
-
-    with pytest.raises(SystemExit) as exc_info:
-        load_state(["load", "-h"])
-
-    assert exc_info.value.code == 0
-    fake_warning.assert_called_once_with("\nUsage:\n")
 
 def test_load_state_specific_id(mocker):
     save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg"}]
@@ -133,7 +115,7 @@ def test_load_state_specific_id(mocker):
     fake_run = mocker.patch("pygitgo.commands.state.run_command")
     fake_success = mocker.patch("pygitgo.commands.state.success")
 
-    load_state(["load", "1"])
+    load_state("1")
 
     fake_run.assert_called_once_with(["git", "stash", "apply", "0"])
     fake_success.assert_called_once_with("\nState 'msg' loaded successfully.\n")
@@ -144,7 +126,7 @@ def test_load_state_invalid_id(mocker):
     mocker.patch("pygitgo.commands.state.validate_state_id", return_value=False)
 
     with pytest.raises(SystemExit) as exc_info:
-        load_state(["load", "100"])
+        load_state("100")
 
     assert exc_info.value.code == 1
 
@@ -154,7 +136,7 @@ def test_load_state_invalid_argument(mocker):
     fake_error = mocker.patch("pygitgo.commands.state.error")
 
     with pytest.raises(SystemExit) as exc_info:
-        load_state(["load", "invalid_arg"])
+        load_state("invalid_arg")
 
     assert exc_info.value.code == 1
     fake_error.assert_called_once_with("\nInvalid argument 'invalid_arg' for load operation. Expected a state ID.\n")
@@ -167,34 +149,17 @@ def test_load_state_no_args(mocker):
     fake_run = mocker.patch("pygitgo.commands.state.run_command")
     fake_success = mocker.patch("pygitgo.commands.state.success")
 
-    load_state(["load"])
+    load_state()
 
     fake_run.assert_called_once_with(["git", "stash", "apply", "1"])
     fake_success.assert_called_once_with("\nState 'msg2' loaded successfully.\n")
 
-def test_save_state_too_many_args(mocker):
-    fake_error = mocker.patch("pygitgo.commands.state.error")
-
-    with pytest.raises(SystemExit) as exc_info:
-        save_state(["save", "name", "extra"])
-
-    assert exc_info.value.code == 1
-    fake_error.assert_called_once_with("\nToo many arguments for save operation!\n")
-
-def test_save_state_help(mocker):
-    fake_warning = mocker.patch("pygitgo.commands.state.warning")
-
-    with pytest.raises(SystemExit) as exc_info:
-        save_state(["save", "-h"])
-
-    assert exc_info.value.code == 0
-    fake_warning.assert_called_once_with("\nUsage:\n")
 
 def test_save_state_no_args(mocker):
     fake_run = mocker.patch("pygitgo.commands.state.run_command")
     fake_success = mocker.patch("pygitgo.commands.state.success")
 
-    save_state(["save"])
+    save_state()
 
     fake_run.assert_called_once_with(["git", "stash", "push", "-m", "Auto-Save"])
     fake_success.assert_called_once_with("\nState 'Auto-Save' saved successfully.\n")
@@ -203,28 +168,11 @@ def test_save_state_with_name(mocker):
     fake_run = mocker.patch("pygitgo.commands.state.run_command")
     fake_success = mocker.patch("pygitgo.commands.state.success")
 
-    save_state(["save", "My-State"])
+    save_state("My-State")
 
     fake_run.assert_called_once_with(["git", "stash", "push", "-m", "My-State"])
     fake_success.assert_called_once_with("\nState 'My-State' saved successfully.\n")
 
-def test_delete_state_too_many_args(mocker):
-    fake_error = mocker.patch("pygitgo.commands.state.error")
-
-    with pytest.raises(SystemExit) as exc_info:
-        delete_state(["delete", "1", "extra"])
-
-    assert exc_info.value.code == 1
-    fake_error.assert_called_once_with("\nToo many arguments for delete operation!\n")
-
-def test_delete_state_help(mocker):
-    fake_warning = mocker.patch("pygitgo.commands.state.warning")
-
-    with pytest.raises(SystemExit) as exc_info:
-        delete_state(["delete", "-h"])
-
-    assert exc_info.value.code == 0
-    fake_warning.assert_called_once_with("\nUsage:\n")
 
 def test_delete_state_all_confirm(mocker):
     mocker.patch("builtins.input", return_value="y")
@@ -232,7 +180,7 @@ def test_delete_state_all_confirm(mocker):
     fake_success = mocker.patch("pygitgo.commands.state.success")
 
     with pytest.raises(SystemExit) as exc_info:
-        delete_state(["delete", "-a"])
+        delete_state("-a")
 
     assert exc_info.value.code == 0
     fake_run.assert_called_once_with(["git", "stash", "clear"])
@@ -243,7 +191,7 @@ def test_delete_state_all_cancel(mocker):
     fake_warning = mocker.patch("pygitgo.commands.state.warning")
 
     with pytest.raises(SystemExit) as exc_info:
-        delete_state(["delete", "-a"])
+        delete_state("-a")
 
     assert exc_info.value.code == 0
     fake_warning.assert_called_once_with("\nDelete operation cancelled by user.\n")
@@ -252,7 +200,7 @@ def test_delete_state_invalid_id(mocker):
     fake_error = mocker.patch("pygitgo.commands.state.error")
     
     with pytest.raises(SystemExit) as exc_info:
-        delete_state(["delete", "abc"])
+        delete_state("abc")
 
     assert exc_info.value.code == 1
     fake_error.assert_called_once_with("\nInvalid input. Please enter a valid state ID.\n")
@@ -263,7 +211,7 @@ def test_delete_state_specific_id(mocker):
     fake_run = mocker.patch("pygitgo.commands.state.run_command")
     fake_success = mocker.patch("pygitgo.commands.state.success")
 
-    delete_state(["delete", "1"])
+    delete_state("1")
 
     fake_run.assert_called_once_with(["git", "stash", "drop", "0"])
     fake_success.assert_called_once_with("\nState with ID '1' deleted successfully.\n")
@@ -274,7 +222,7 @@ def test_delete_state_no_args(mocker):
     fake_run = mocker.patch("pygitgo.commands.state.run_command")
     fake_success = mocker.patch("pygitgo.commands.state.success")
 
-    delete_state(["delete"])
+    delete_state()
 
     fake_run.assert_called_once_with(["git", "stash", "drop", "1"])
     fake_success.assert_called_once_with("\nState with ID '2' deleted successfully.\n")


### PR DESCRIPTION
## What Changed
- Replaced manual `sys.argv` parsing with Python's `argparse` module
- Added new `gitgo config` command for setting user defaults
- Removed redundant help functions and argument validation logic
- All commands now support standard `-h` help flags automatically

## New Feature
Users can now set their own defaults:
- `gitgo config set default-branch <name>`
- `gitgo config set default-message "<msg>"`
- `gitgo config get <key>`

Settings are saved in `git config --global` under the `gitgo.*` namespace.

## Notes
This was implemented in response to the config feature request in #25.

Closes #25