### PR TITLE
feat: add silent background update checker with PyPI caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ GitGo provides a CLI environment designed for faster and simpler Git workflows. 
 - **Smart Branch Hopping:** Safely traverse branches with `jump`. Auto-stashes messy code and prevents merge conflict disasters with a Try-And-Revert safety engine.
 - **State Management:** A human-readable interface over `git stash`. States are named and listed by index so you never have to remember cryptic stash references.
 - **Custom Defaults:** Save your preferred branch name and commit message locally so you never have to type them again.
+- **Auto-Update Checker:** Silently checks for newer versions in the background and notifies you, without slowing down your commands.
 - **SSH Auto-Setup:** Generates an SSH key, adds it to `ssh-agent`, and opens your GitHub settings automatically.
 - **HTTPS to SSH Conversion:** Silently converts the remote to SSH before pushing if your SSH is configured.
 - **Termux Compatibility:** Works natively on Android natively handling common issues like dubious ownership errors.
@@ -258,6 +259,7 @@ gitgo -r        # verify GitGo is ready
 
 - **SSH Auto-Setup:** `gitgo user login` generates an `ed25519` SSH key, adds it to `ssh-agent`, prints the public key, and opens `github.com/settings/ssh/new`.
 - **HTTPS to SSH Conversion:** If your remote is set to HTTPS, GitGo converts the remote to SSH before pushing if SSH is configured. No `git remote set-url` is required.
+- **Auto-Update Checker:** Spawns a non-blocking background thread on startup to query PyPI for newer versions. Results are cached locally for 7 days to prevent unnecessary network requests.
 - **Termux Compatibility:** Detects Termux via environment variables, adjusts binary locations (`$PREFIX/bin`), uses `termux-open` for browser actions, and natively handles the `detected dubious ownership` Git error.
 - **State Management:** `gitgo state` wraps `git stash` with named saves, indexed listing, and confirmation prompts.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.5.0"
+version = "1.6.0"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -6,6 +6,7 @@ from pygitgo.commands.staging import get_changed_files, display_file_picker, sel
 from pygitgo.utils.colors import info, success, warning, error
 from pygitgo.utils.config import get_config, config_operation
 from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.utils.update_checker import check_for_updates_background
 from pygitgo.utils.setup import ensure_first_run_setup
 from pygitgo.commands.state import state_operations
 from pygitgo.commands.undo import undo_operations
@@ -337,6 +338,7 @@ def main():
         sys.exit(0)
 
     ensure_first_run_setup()
+    check_for_updates_background(get_version())
 
     try:
         if args.command == "jump":

--- a/src/pygitgo/utils/update_checker.py
+++ b/src/pygitgo/utils/update_checker.py
@@ -1,0 +1,97 @@
+import json
+import threading
+import urllib.request
+import urllib.error
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from pygitgo.utils.colors import info, warning
+
+
+CACHE_DIR = Path.home() / ".gitgo"
+CACHE_FILE = CACHE_DIR / "update_check.json"
+PYPI_URL = "https://pypi.org/pypi/pygitgo/json"
+CHECK_INTERVAL = timedelta(days=7)
+REQUEST_TIMEOUT = 2
+
+
+def read_cache():
+    if not CACHE_FILE.exists():
+        return {}
+    try:
+        with open(CACHE_FILE, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return {}
+
+
+def write_cache(data):
+    try:
+        CACHE_DIR.mkdir(exist_ok=True)
+        with open(CACHE_FILE, "w") as f:
+            json.dump(data, f)
+    except IOError:
+        pass
+
+
+def should_check():
+    cache = read_cache()
+    last_check = cache.get("last_check")
+
+    if not last_check:
+        return True
+
+    try:
+        last_check_time = datetime.fromisoformat(last_check)
+        return (datetime.now() - last_check_time) > CHECK_INTERVAL
+    except ValueError:
+        return True
+
+
+def get_latest_version():
+    try:
+        with urllib.request.urlopen(PYPI_URL, timeout=REQUEST_TIMEOUT) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            return data["info"]["version"]
+    except Exception:
+        return None
+
+
+def parse_version(version_string):
+    parts = [int(x) for x in version_string.split(".")]
+    while len(parts) < 3:
+        parts.append(0)
+    return parts
+
+
+def check_for_updates(current_version):
+    if not should_check():
+        return
+
+    cache = read_cache()
+    cache["last_check"] = datetime.now().isoformat()
+    write_cache(cache)
+
+    latest_version = get_latest_version()
+    if not latest_version or latest_version == current_version:
+        return
+
+    try:
+        current_parts = parse_version(current_version)
+        latest_parts = parse_version(latest_version)
+
+        if latest_parts > current_parts:
+            print()
+            warning(f"GitGo update available: {current_version} -> {latest_version}")
+            info("Run: pip install --upgrade pygitgo")
+            print()
+
+            cache["notified_version"] = latest_version
+            write_cache(cache)
+    except (ValueError, AttributeError):
+        pass
+
+
+def check_for_updates_background(current_version):
+    thread = threading.Thread(target=check_for_updates, args=(current_version,), daemon=True)
+    thread.start()

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -1,0 +1,143 @@
+from pygitgo.utils.update_checker import (
+    read_cache, write_cache, should_check, get_latest_version,
+    parse_version, check_for_updates, check_for_updates_background,
+    CACHE_FILE
+)
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+import json
+
+
+def test_read_cache_empty(tmp_path, mocker):
+    mocker.patch("pygitgo.utils.update_checker.CACHE_FILE", tmp_path / "missing.json")
+    assert read_cache() == {}
+
+
+def test_read_cache_valid(tmp_path, mocker):
+    cache_file = tmp_path / "update_check.json"
+    cache_file.write_text(json.dumps({"last_check": "2026-01-01T00:00:00"}))
+    mocker.patch("pygitgo.utils.update_checker.CACHE_FILE", cache_file)
+    result = read_cache()
+    assert result["last_check"] == "2026-01-01T00:00:00"
+
+
+def test_read_cache_corrupted(tmp_path, mocker):
+    cache_file = tmp_path / "update_check.json"
+    cache_file.write_text("not json")
+    mocker.patch("pygitgo.utils.update_checker.CACHE_FILE", cache_file)
+    assert read_cache() == {}
+
+
+def test_write_cache(tmp_path, mocker):
+    cache_file = tmp_path / "update_check.json"
+    mocker.patch("pygitgo.utils.update_checker.CACHE_DIR", tmp_path)
+    mocker.patch("pygitgo.utils.update_checker.CACHE_FILE", cache_file)
+    write_cache({"last_check": "2026-01-01T00:00:00"})
+    result = json.loads(cache_file.read_text())
+    assert result["last_check"] == "2026-01-01T00:00:00"
+
+
+def test_should_check_no_cache(mocker):
+    mocker.patch("pygitgo.utils.update_checker.read_cache", return_value={})
+    assert should_check() is True
+
+
+def test_should_check_expired(mocker):
+    old_date = (datetime.now() - timedelta(days=8)).isoformat()
+    mocker.patch("pygitgo.utils.update_checker.read_cache", return_value={"last_check": old_date})
+    assert should_check() is True
+
+
+def test_should_check_still_valid(mocker):
+    recent_date = (datetime.now() - timedelta(days=1)).isoformat()
+    mocker.patch("pygitgo.utils.update_checker.read_cache", return_value={"last_check": recent_date})
+    assert should_check() is False
+
+
+def test_should_check_invalid_date(mocker):
+    mocker.patch("pygitgo.utils.update_checker.read_cache", return_value={"last_check": "not-a-date"})
+    assert should_check() is True
+
+
+def test_parse_version_standard():
+    assert parse_version("1.5.0") == [1, 5, 0]
+
+
+def test_parse_version_short():
+    assert parse_version("2.0") == [2, 0, 0]
+
+
+def test_parse_version_comparison():
+    assert parse_version("1.6.0") > parse_version("1.5.0")
+    assert parse_version("2.0.0") > parse_version("1.9.9")
+    assert parse_version("1.5.0") == parse_version("1.5.0")
+
+
+def test_get_latest_version_success(mocker):
+    fake_response = MagicMock()
+    fake_response.read.return_value = json.dumps({"info": {"version": "1.6.0"}}).encode("utf-8")
+    fake_response.__enter__ = lambda s: s
+    fake_response.__exit__ = MagicMock(return_value=False)
+    mocker.patch("pygitgo.utils.update_checker.urllib.request.urlopen", return_value=fake_response)
+    assert get_latest_version() == "1.6.0"
+
+
+def test_get_latest_version_network_failure(mocker):
+    mocker.patch("pygitgo.utils.update_checker.urllib.request.urlopen", side_effect=Exception("timeout"))
+    assert get_latest_version() is None
+
+
+def test_check_for_updates_skips_when_cached(mocker):
+    mocker.patch("pygitgo.utils.update_checker.should_check", return_value=False)
+    fake_get = mocker.patch("pygitgo.utils.update_checker.get_latest_version")
+    check_for_updates("1.5.0")
+    fake_get.assert_not_called()
+
+
+def test_check_for_updates_no_update_available(mocker):
+    mocker.patch("pygitgo.utils.update_checker.should_check", return_value=True)
+    mocker.patch("pygitgo.utils.update_checker.read_cache", return_value={})
+    mocker.patch("pygitgo.utils.update_checker.write_cache")
+    mocker.patch("pygitgo.utils.update_checker.get_latest_version", return_value="1.5.0")
+    fake_warning = mocker.patch("pygitgo.utils.update_checker.warning")
+    check_for_updates("1.5.0")
+    fake_warning.assert_not_called()
+
+
+def test_check_for_updates_newer_version_available(mocker):
+    mocker.patch("pygitgo.utils.update_checker.should_check", return_value=True)
+    mocker.patch("pygitgo.utils.update_checker.read_cache", return_value={})
+    mocker.patch("pygitgo.utils.update_checker.write_cache")
+    mocker.patch("pygitgo.utils.update_checker.get_latest_version", return_value="2.0.0")
+    fake_warning = mocker.patch("pygitgo.utils.update_checker.warning")
+    fake_info = mocker.patch("pygitgo.utils.update_checker.info")
+    check_for_updates("1.5.0")
+    fake_warning.assert_called_with("GitGo update available: 1.5.0 -> 2.0.0")
+    fake_info.assert_called_with("Run: pip install --upgrade pygitgo")
+
+
+def test_check_for_updates_older_version_on_pypi(mocker):
+    mocker.patch("pygitgo.utils.update_checker.should_check", return_value=True)
+    mocker.patch("pygitgo.utils.update_checker.read_cache", return_value={})
+    mocker.patch("pygitgo.utils.update_checker.write_cache")
+    mocker.patch("pygitgo.utils.update_checker.get_latest_version", return_value="1.4.0")
+    fake_warning = mocker.patch("pygitgo.utils.update_checker.warning")
+    check_for_updates("1.5.0")
+    fake_warning.assert_not_called()
+
+
+def test_check_for_updates_pypi_returns_none(mocker):
+    mocker.patch("pygitgo.utils.update_checker.should_check", return_value=True)
+    mocker.patch("pygitgo.utils.update_checker.read_cache", return_value={})
+    mocker.patch("pygitgo.utils.update_checker.write_cache")
+    mocker.patch("pygitgo.utils.update_checker.get_latest_version", return_value=None)
+    fake_warning = mocker.patch("pygitgo.utils.update_checker.warning")
+    check_for_updates("1.5.0")
+    fake_warning.assert_not_called()
+
+
+def test_check_for_updates_background_starts_thread(mocker):
+    fake_thread = MagicMock()
+    mocker.patch("pygitgo.utils.update_checker.threading.Thread", return_value=fake_thread)
+    check_for_updates_background("1.5.0")
+    fake_thread.start.assert_called_once()


### PR DESCRIPTION
## What's New?

GitGo now checks PyPI for newer versions in the background when you run any command. If an update is found, it shows a one-line notice with the upgrade command.

How it works:
- Runs in a background thread so it never slows down your commands
- Caches the result and only checks once every 7 days
- Fails silently if there is no internet or PyPI is unreachable
- Stores the cache at ~/.gitgo/update_check.json