### PR TITLE
fix: prevent ssh hang during login and improve browser fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - (nothing yet)
 
 ### Fixed
-- (nothing yet)
+- Fixed GitGo hanging indefinitely during login if an SSH passphrase prompt was triggered invisibly.
+- Fixed the browser failing to open in some environments by always printing the GitHub URL as a fallback.
+- Improved login failure messaging to suggest concrete fixes (like checking the SSH agent).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.6.2"
+version = "1.6.3"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/auth/manager.py
+++ b/src/pygitgo/auth/manager.py
@@ -33,18 +33,16 @@ def login():
         
         info("Copy the key above (between the lines).")
 
-        input(
-            "\nPress Enter to open your GitHub SSH key settings page in the browser...\n"
-            "Make sure you are logged in so you can add your new key. "
-            "After adding, return here to continue."
-        )
         ssh_utils.open_github_settings()
+
+        input(
+            "After pasting your key on GitHub and clicking 'Add SSH Key',\n"
+            "come back here and press Enter to verify the connection..."
+        )
 
     else:
         error("Failed to read the generated public key.")
         return False
-    
-    input("\nPress Enter after adding the key to GitHub...")
 
     if ssh_utils.check_connection():
         from .account import ensure_user_configure
@@ -56,7 +54,11 @@ def login():
         success("\nLogin Successful! You are connected.\n")
         return True
     
-    error("Login Failed. Please try again.")
+    error("Login Failed. The SSH key may not have been added to GitHub correctly.")
+    info("Possible causes:")
+    info("  1. The key was not pasted on GitHub")
+    info("  2. SSH agent is not running (try: eval $(ssh-agent) && ssh-add)")
+    info("  3. Network or firewall is blocking SSH connections")
     return False
     
 def logout():

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 import os
 
+SSH_TIMEOUT_SECONDS = 10
+
 
 
 def ensure_github_known_host():
@@ -34,24 +36,37 @@ def ensure_github_known_host():
 
 def check_connection():
     ensure_github_known_host()
-    result = run_command(["ssh", "-T", "git@github.com"], allow_fail=True, return_complete=True)
-    if not hasattr(result, "stderr") or not result.stderr:
+    try:
+        result = subprocess.run(
+            ["ssh", "-T", "-o", "BatchMode=yes", "git@github.com"],
+            capture_output=True,
+            text=True,
+            timeout=SSH_TIMEOUT_SECONDS,
+            stdin=subprocess.DEVNULL,
+        )
+        output = (result.stderr or "") + (result.stdout or "")
+        return "successfully authenticated" in output
+    except (subprocess.TimeoutExpired, OSError):
         return False
-    return "successfully authenticated" in result.stderr
 
 def get_github_username():
+    try:
+        result = subprocess.run(
+            ["ssh", "-T", "-o", "BatchMode=yes", "git@github.com"],
+            capture_output=True,
+            text=True,
+            timeout=SSH_TIMEOUT_SECONDS,
+            stdin=subprocess.DEVNULL,
+        )
+        output = (result.stderr or "") + (result.stdout or "")
 
-    result = run_command(["ssh", "-T", "git@github.com"], allow_fail=True, return_complete=True)
-    if not hasattr(result, "stderr") or not result.stderr:
-        return None
-    output = result.stderr
-    
-    if "Hi " in output and "!" in output:
-        try:
-            username = output.split("Hi ")[1].split("!")[0]
-            return username
-        except:
-            return None
+        if "Hi " in output and "!" in output:
+            try:
+                return output.split("Hi ")[1].split("!")[0]
+            except (IndexError, ValueError):
+                return None
+    except (subprocess.TimeoutExpired, OSError):
+        pass
     return None
 
 def get_ssh_key_path():
@@ -89,15 +104,30 @@ def generate_ssh_key(email):
 
 def open_github_settings():
     url = "https://github.com/settings/ssh/new"
-    if platform_utils.is_windows():
-        os.system(f"start {url}")
-    elif platform_utils.is_termux():
-        os.system(f"termux-open {url}")
-    elif platform_utils.is_linux() or platform_utils.is_macos():
-        os.system(f"xdg-open {url}")
-    else:
-        import webbrowser
-        webbrowser.open(url)
+    opened = False
+
+    try:
+        if platform_utils.is_windows():
+            os.system(f"start {url}")
+            opened = True
+        elif platform_utils.is_termux():
+            os.system(f"termux-open {url}")
+            opened = True
+        elif platform_utils.is_linux() or platform_utils.is_macos():
+            exit_code = os.system(f"xdg-open {url} 2>/dev/null")
+            opened = exit_code == 0
+        else:
+            import webbrowser
+            webbrowser.open(url)
+            opened = True
+    except Exception:
+        opened = False
+
+    if not opened:
+        warning("Could not open browser automatically.")
+
+    info(f"\nIf the browser did not open, visit this URL manually:")
+    print(f"\n  {url}\n")
 
 
 def convert_https_to_ssh(url):


### PR DESCRIPTION
<!-- If you are unsure how to fill this out, see CONTRIBUTING.md: https://github.com/Huerte/GitGo/blob/main/CONTRIBUTING.md -->
<!-- Note: These hidden comments guide you while typing. GitHub hides them automatically when you submit. -->

## Type

<!-- Check the one that fits. Put an 'x' inside the brackets: [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal

## Overview
This fixes a bug where `gitgo user login` would freeze forever if the user's ssh agent wasn't running. the ssh command was waiting for a passphrase, but because we capture the output, the prompt was invisible. i also fixed the browser auto-open so it prints the github url if the browser fails to open.

## Changes

- `ssh_utils.py`: added `BatchMode=yes`, timeouts, and `stdin=DEVNULL` to the ssh connection checks so they fail fast instead of hanging.
- `ssh_utils.py`: updated the `open_github_settings` function to catch errors and always print the target url as a fallback.
- `manager.py`: changed the login flow so the browser opens instantly, and improved the error messages if login fails.

## How to Test
1. `pip install -e ".[dev]"`
2. run `gitgo user login`
3. see that it doesn't freeze anymore and properly reports that the login failed.
4. Expected result: the tool should open the browser (or print the url) and eventually return a clear error message instead of hanging forever.

## Checklist

<!-- Put an 'x' inside the brackets to check a box: [x] -->

- [x] I tested my changes locally and they work
- [x] I updated `CHANGELOG.md` under the [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md) section
- [ ] I updated `README.md` (if I added or changed a command)
- [ ] I added or updated tests for my change (if applicable)
- [x] My change does not break any existing commands (if it does, describe the impact in the Overview)