### PR TITLE
fix: resolve state command parsing, ordering, and edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed GitGo hanging indefinitely during login if an SSH passphrase prompt was triggered invisibly.
 - Fixed the browser failing to open in some environments by always printing the GitHub URL as a fallback.
 - Improved login failure messaging to suggest concrete fixes (like checking the SSH agent).
+- Fixed `gitgo state` not parsing short-form aliases (`-l`, `-s`, `-o`, `-d`) correctly.
+- Fixed chronological ordering in `gitgo state list` (now displays old to new, numbered 1, 2, 3) and accurately maps IDs to Git's internal stash index.
+- Fixed `gitgo state` crashing when parsing stashes that output dates instead of indices.
+- Fixed `gitgo state load` attempting to run even when no states exist.
+- Fixed `gitgo state` silently accepting conflicting inputs (like `gitgo state list -s`).
+- Fixed `-a / --all` flag applying to all state actions; it is now strictly locked to `delete`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.7.0b1"
+version = "1.7.0b2"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -7,12 +7,6 @@ from pygitgo.utils.executor import run_command, command_failed
 from pygitgo.exceptions import GitGoError
 
 
-ALIASES = {
-    "-l": "list",
-    "-s": "save",
-    "-o": "load",
-    "-d": "delete"
-}
 
 def all_save_state():
     output = git_stash_list()
@@ -21,20 +15,20 @@ def all_save_state():
         return []
 
     save_states = []
+    lines = output.splitlines()
+    total = len(lines)
 
-    for line in output.splitlines():
+    for i, line in enumerate(reversed(lines)):
         try:
             stash_ref, date, message = line.split("||", 2)
-
-            index = int(
-                stash_ref.replace("stash@{", "").replace("}", "")
-            )
+            stash_index = total - 1 - i
 
             save_states.append({
-                "id": index + 1,   
-                "ref": stash_ref,  
+                "id": i + 1,   
+                "ref": f"stash@{{{stash_index}}}",  
                 "date": date,
-                "message": message
+                "message": message,
+                "stash_index": stash_index
             })
 
         except ValueError:
@@ -103,6 +97,11 @@ def state_list():
 
 def load_state(state_id=None):
     save_states = all_save_state()
+    
+    if not save_states:
+        warning("\nNo saved states to load.\n")
+        return
+
     proceed = False
 
     if state_id:
@@ -118,11 +117,13 @@ def load_state(state_id=None):
         if not state_id:
             return
         
-    apply_result = git_stash_apply(stash_id=str(int(state_id) - 1))
+    selected_state = save_states[int(state_id) - 1]
+        
+    apply_result = git_stash_apply(stash_id=str(selected_state["stash_index"]))
     if not apply_result:
         error(f"\nFailed to load state. There may be a conflict with your current changes.\n")
         raise GitGoError()
-    success(f"\nState '{save_states[int(state_id) - 1]['message']}' loaded successfully.\n")
+    success(f"\nState '{selected_state['message']}' loaded successfully.\n")
 
 
 def save_state(state_name=None):
@@ -170,7 +171,9 @@ def delete_state(identifier=None):
         if not validate_state_id(state_id, save_states):
             raise GitGoError()
     
-    drop_result = git_stash_drop(stash_id=str(int(state_id) - 1))
+    selected_state = save_states[int(state_id) - 1]
+    
+    drop_result = git_stash_drop(stash_id=str(selected_state["stash_index"]))
     if not drop_result:
         error(f"\nFailed to delete state with ID '{state_id}'.\n")
         raise GitGoError()
@@ -178,8 +181,26 @@ def delete_state(identifier=None):
 
 
 def state_operations(args):
-    action = ALIASES.get(args.action, args.action)
+    alias = getattr(args, "action_alias", None)
+    positional = getattr(args, "action", None)
+
+    if alias and positional and alias != positional:
+        raise GitGoError(
+            f"\nConflicting actions: '{positional}' and '{alias}'. Use one or the other.\n"
+        )
+
+    action = alias or positional
     identifier = getattr(args, "identifier", None)
+    
+    if getattr(args, "all", False):
+        if action != "delete":
+            raise GitGoError(
+                "\nThe -a/--all flag is only valid with the delete action.\n"
+            )
+        identifier = "-a"
+    
+    if not action:
+        raise GitGoError("\nMissing action. Please specify an action (list, save, load, delete) or use a flag (-l, -s, -o, -d).\n")
 
     if action == "list":
         state_list()

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -254,15 +254,28 @@ def main():
     )
     state_parser.add_argument(
         "action",
-        choices=["list", "save", "load", "delete", "-l", "-s", "-o", "-d"],
+        nargs="?",
+        choices=["list", "save", "load", "delete"],
         metavar="action",
-        help="list, save, load, delete  (aliases: -l, -s, -o, -d)"
+        default=None,
+        help="list, save, load, delete"
     )
     state_parser.add_argument(
         "identifier",
         nargs="?",
         default=None,
         help="Optional name or ID"
+    )
+    _alias_group = state_parser.add_mutually_exclusive_group()
+    _alias_group.add_argument("-l", dest="action_alias", action="store_const", const="list",   help="Alias for 'list'")
+    _alias_group.add_argument("-s", dest="action_alias", action="store_const", const="save",   help="Alias for 'save'")
+    _alias_group.add_argument("-o", dest="action_alias", action="store_const", const="load",   help="Alias for 'load'")
+    _alias_group.add_argument("-d", dest="action_alias", action="store_const", const="delete", help="Alias for 'delete'")
+
+    state_parser.add_argument(
+        "-a", "--all",
+        action="store_true",
+        help="Apply action to all states (e.g., delete all)"
     )
     
     user_parser = subparsers.add_parser("user", help="Manage Git user identity")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -57,12 +57,14 @@ def test_all_save_state_with_output(mocker):
 
     assert len(result) == 2
     assert result[0] == {
-        "id": 1, "ref": "stash@{0}",
-        "date": "2023-10-27 10:00:00", "message": "Test stash"
+        "id": 1, "ref": "stash@{1}",
+        "date": "2023-10-27 10:05:00", "message": "Another stash",
+        "stash_index": 1
     }
     assert result[1] == {
-        "id": 2, "ref": "stash@{1}",
-        "date": "2023-10-27 10:05:00", "message": "Another stash"
+        "id": 2, "ref": "stash@{0}",
+        "date": "2023-10-27 10:00:00", "message": "Test stash",
+        "stash_index": 0
     }
 
 
@@ -83,7 +85,7 @@ def test_all_save_state_malformed_line(mocker):
 # ---------------------------------------------------------------------------
 
 def test_load_state_specific_id(mocker):
-    save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg"}]
+    save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg", "stash_index": 0}]
     mocker.patch("pygitgo.commands.state.all_save_state", return_value=save_states)
     mocker.patch("pygitgo.commands.state.validate_state_id", return_value=True)
     fake_apply = mocker.patch("pygitgo.commands.state.git_stash_apply", return_value=True)
@@ -96,7 +98,7 @@ def test_load_state_specific_id(mocker):
 
 
 def test_load_state_invalid_id(mocker):
-    save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg"}]
+    save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg", "stash_index": 0}]
     mocker.patch("pygitgo.commands.state.all_save_state", return_value=save_states)
     mocker.patch("pygitgo.commands.state.validate_state_id", return_value=False)
 
@@ -106,7 +108,7 @@ def test_load_state_invalid_id(mocker):
 
 
 def test_load_state_invalid_argument(mocker):
-    save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg"}]
+    save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg", "stash_index": 0}]
     mocker.patch("pygitgo.commands.state.all_save_state", return_value=save_states)
 
     from pygitgo.exceptions import GitGoError
@@ -116,8 +118,8 @@ def test_load_state_invalid_argument(mocker):
 
 def test_load_state_no_args(mocker):
     save_states = [
-        {"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg"},
-        {"id": 2, "ref": "stash@{1}", "date": "date2", "message": "msg2"},
+        {"id": 1, "ref": "stash@{1}", "date": "date", "message": "msg", "stash_index": 1},
+        {"id": 2, "ref": "stash@{0}", "date": "date2", "message": "msg2", "stash_index": 0},
     ]
     mocker.patch("pygitgo.commands.state.all_save_state", return_value=save_states)
     mocker.patch("pygitgo.commands.state.ask_state_id", return_value="2")
@@ -126,7 +128,7 @@ def test_load_state_no_args(mocker):
 
     load_state()
 
-    fake_apply.assert_called_once_with(stash_id="1")
+    fake_apply.assert_called_once_with(stash_id="0")
     fake_success.assert_called_once_with("\nState 'msg2' loaded successfully.\n")
 
 
@@ -197,7 +199,7 @@ def test_delete_state_invalid_id(mocker):
 
 
 def test_delete_state_specific_id(mocker):
-    save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg"}]
+    save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg", "stash_index": 0}]
     mocker.patch("pygitgo.commands.state.validate_state_id", return_value=True)
     mocker.patch("pygitgo.commands.state.all_save_state", return_value=save_states)
     fake_drop = mocker.patch("pygitgo.commands.state.git_stash_drop", return_value=True)
@@ -211,8 +213,8 @@ def test_delete_state_specific_id(mocker):
 
 def test_delete_state_no_args(mocker):
     save_states = [
-        {"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg"},
-        {"id": 2, "ref": "stash@{1}", "date": "date2", "message": "msg2"},
+        {"id": 1, "ref": "stash@{1}", "date": "date", "message": "msg", "stash_index": 1},
+        {"id": 2, "ref": "stash@{0}", "date": "date2", "message": "msg2", "stash_index": 0},
     ]
     mocker.patch("pygitgo.commands.state.all_save_state", return_value=save_states)
     mocker.patch("pygitgo.commands.state.ask_state_id", return_value="2")
@@ -221,5 +223,5 @@ def test_delete_state_no_args(mocker):
 
     delete_state()
 
-    fake_drop.assert_called_once_with(stash_id="1")
+    fake_drop.assert_called_once_with(stash_id="0")
     fake_success.assert_called_once_with("\nState with ID '2' deleted successfully.\n")


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal

## Overview

this fixes several bugs with the `gitgo state` command. the parser now handles aliases correctly, the display order is fixed to show chronological order, and some missing guards and edge cases are now covered. 

## Changes

- `gitgo state`: fixed argparse rejecting short-form aliases like `-l` and `-s`.
- `gitgo state list`: fixed states displaying in reverse chronological order. they now print oldest to newest with 1, 2, 3 numbering.
- internal: updated the math so visual IDs map to the correct git stash index under the hood.
- `gitgo state`: patched a crash that happened when git outputs dates instead of indices for stash refs.
- `gitgo state load`: added a guard to prevent loading when no states exist.
- `gitgo state`: added validation to reject conflicting inputs like `gitgo state list -s`.
- `gitgo state delete`: locked the `-a` and `--all` flags strictly to the delete action so they aren't accepted elsewhere.

## How to Test

1. `pip install -e ".[dev]"`
2. run `gitgo state save 'test state'` and then `gitgo state list`.
3. Expected result: the state is saved, the list command doesn't crash, and it prints with ID 1.
4. run `pytest tests/`
5. Expected result: all tests pass successfully.

## Checklist

- [x] I tested my changes locally and they work
- [x] I updated `CHANGELOG.md` under the [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md) section
- [ ] I updated `README.md` (if I added or changed a command)
- [x] I added or updated tests for my change (if applicable)
- [x] My change does not break any existing commands (if it does, describe the impact in the Overview)