### PR TITLE
fix: resolve unconditional fall-through bugs across core commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed `gitgo state load` attempting to run even when no states exist.
 - Fixed `gitgo state` silently accepting conflicting inputs (like `gitgo state list -s`).
 - Fixed `-a / --all` flag applying to all state actions; it is now strictly locked to `delete`.
+- Fixed `gitgo link` running `git add .` on existing repositories, which staged unwanted files.
+- Fixed `gitgo push --select` ignoring your selection and committing everything anyway.
+- Fixed `gitgo user login` crashing when an invalid email was provided or if `ssh-keygen` failed.
+- Fixed `gitgo user logout` wiping git config even if SSH key deletion failed.
+- Fixed `gitgo jump` running a slow network pull when creating a brand new local branch.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.7.0b2"
+version = "1.7.0b3"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/auth/manager.py
+++ b/src/pygitgo/auth/manager.py
@@ -72,13 +72,19 @@ def logout():
         return False
     
     try:
+        
+        os.remove(key_path)
+
+        pub_key_path = str(key_path) + ".pub"
+        if os.path.exists(pub_key_path):
+            os.remove(pub_key_path)
+
         run_command(["git", "config", "--global", "--unset-all", "user.name"], allow_fail=True)
         run_command(["git", "config", "--global", "--unset-all", "user.email"], allow_fail=True)
         
-        os.remove(key_path)
-        os.remove(str(key_path) + '.pub')
         success("User successfully logout")
         return True
+    
     except Exception as e:
         error(f"Failed to remove SSH keys\nCAUSE OF ERROR: {e}")
         return False

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -1,7 +1,7 @@
 from pygitgo.utils import platform_utils
 from pygitgo.utils.colors import info, success, warning, error
 from pygitgo.utils.executor import run_command, command_failed
-from pygitgo.exceptions import GitCommandError
+from pygitgo.exceptions import GitCommandError, GitGoError
 from pathlib import Path
 import webbrowser
 import subprocess
@@ -11,7 +11,6 @@ import re
 
 
 SSH_TIMEOUT_SECONDS = 10
-
 
 
 def ensure_github_known_host():
@@ -68,8 +67,7 @@ def get_ssh_key_path():
 
 def generate_ssh_key(email):
     if not email or "@" not in email or "." not in email:
-        error("Invalid email address provided for SSH key generation.")
-        return 
+        raise GitGoError("Invalid email address provided for SSH key generation.")
     
     key_path = get_ssh_key_path()
     if not key_path.parent.exists():
@@ -87,14 +85,21 @@ def generate_ssh_key(email):
         "-f", str(key_path),
         "-N", ""
     ]
-    run_command(command=command)
 
+    try:
+        run_command(command=command)
+    except GitCommandError as e:
+        raise GitGoError(
+            "\nFailed to generate SSH key. Is 'ssh-keygen' installed on your system?\n"
+            f"Details: {e}"
+        )
     try:
         run_command(["ssh-add", str(key_path)], allow_fail=True)
     except (GitCommandError, OSError):
         pass 
     
     return key_path
+
 
 def open_github_settings():
     url = "https://github.com/settings/ssh/new"

--- a/src/pygitgo/commands/git_operations.py
+++ b/src/pygitgo/commands/git_operations.py
@@ -57,12 +57,14 @@ def _get_signing_flags():
         "-c", f"user.signingkey={key_path}",
     ]
 
-def git_commit(commit_message, loading_msg="Commiting changes..."):
+def git_commit(commit_message, loading_msg="Commiting changes...", skip_staging=False):
     status_result = run_command(["git", "status", "--porcelain"], allow_fail=True)
     if command_failed(status_result) or not status_result.strip():
         return False
 
-    run_command(["git", "add", "."], loading_msg="Staging files...")
+    if not skip_staging:
+        run_command(["git", "add", "."], loading_msg="Staging files...")
+    
     clean_message = commit_message.strip('"\'')
 
     signing_flags = _get_signing_flags()
@@ -75,7 +77,7 @@ def git_commit(commit_message, loading_msg="Commiting changes..."):
 def git_init():
     if os.path.isdir(".git"):
         warning("Already a git repository! Skipping init...")
-        return True
+        return False
     
     default_main_branch = get_config("default-branch", "main")
 

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -74,17 +74,18 @@ def jump_operation(args):
     else:
         run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...")
 
-    main_branch = get_main_branch()
-    get_origin_updates = run_command(['git', 'pull', 'origin', main_branch], allow_fail=True, loading_msg=f"Downloading the latest updates from '{main_branch}'...")
-    
-    if command_failed(get_origin_updates):
-        warning(f"\nFailed to pull updates from '{main_branch}'. Make sure you have internet or the remote branch exists.")
-        user_input = input("Do you want to stay on the new branch without the latest updates? (y/n): ").strip().lower()
-        if user_input != 'y':
-            undo_jump_operation(original_branch, stashed_code, created_branch)
-            raise GitGoError()
-        else:
-            success(f"\nOkay! You are on the new branch, but without the latest updates from '{main_branch}'.")
+        main_branch = get_main_branch()
+        get_origin_updates = run_command(['git', 'pull', 'origin', main_branch], allow_fail=True, loading_msg=f"Downloading the latest updates from '{main_branch}'...")
+        
+        if command_failed(get_origin_updates):
+            warning(f"\nFailed to pull updates from '{main_branch}'. Make sure you have internet or the remote branch exists.")
+            user_input = input("Do you want to stay on the new branch without the latest updates? (y/n): ").strip().lower()
+            if user_input != 'y':
+                undo_jump_operation(original_branch, stashed_code, created_branch)
+                raise GitGoError()
+            else:
+                success(f"\nOkay! You are on the new branch, but without the latest updates from '{main_branch}'.")
+
 
     if stashed_code:
         apply_result = git_stash_apply(loading_msg="Unpacking your unsaved changes...")

--- a/src/pygitgo/commands/stash_operation.py
+++ b/src/pygitgo/commands/stash_operation.py
@@ -42,8 +42,8 @@ def git_stash_list(loading_msg="Fetching stash list..."):
         "git", "stash", "list",
         "--date=format:%Y-%m-%d %H:%M:%S",
         "--pretty=%gd||%cd||%s"
-    ], allow_fail=True)
+    ], allow_fail=True, loading_msg=loading_msg)
 
 def git_stash_clear(loading_msg="Clearing all stashes..."):
-    result = run_command(["git", "stash", "clear"], allow_fail=True)
+    result = run_command(["git", "stash", "clear"], allow_fail=True, loading_msg=loading_msg)
     return not command_failed(result)

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -48,16 +48,23 @@ def link_operation(args):
     info("\nINITIATING LINK OPERATION...")
     info(f"Target: {repo_url}\n")
     
-    if not git_init():
-        return
+    is_new_repo = git_init()
     
-    git_commit(commit_message, loading_msg="Creating initial commit...")
-    success("Initial commit created.")
+    if not is_new_repo:
+        add_remote_origin(repo_url)
+
+        if confirm_remote_link():
+            success("\nRemote linked to existing repository.")
+            success(f"Ready to push with: gitgo push <branch> 'your message'\n")
+        return
+
+    commit_made = git_commit(commit_message, loading_msg="Creating initial commit...")
+    if commit_made:
+        success("Initial commit created.")
     
     add_remote_origin(repo_url)
     
     if not confirm_remote_link():
-        error("Link operation failed! Check your repository URL.")
         return
     
     current_branch = get_current_branch()
@@ -139,9 +146,11 @@ def push_operation(args):
             return
 
         selective_stage(selected)
-        git_commit(message, loading_msg="Commiting selected files...")
+        commit_made = git_commit(message, loading_msg="Commiting selected files...", skip_staging=True)
         
-        git_push(branch)
+        if commit_made:
+            git_push(branch)
+        
     else:
         commit_made = git_commit(message)
         

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -79,7 +79,7 @@ def test_git_init_already_initialized(mocker):
 
     result = git_init()
 
-    assert result == True
+    assert result == False
     fake_warning.assert_called_once() 
     fake_run.assert_not_called()
 
@@ -472,3 +472,22 @@ def test_check_and_sync_branch_remote_not_exist(mocker):
     fake_run.assert_any_call(
         ["git", "rev-parse", branch]
     )
+
+def test_git_commit_skip_staging_does_not_run_git_add(mocker):
+    mocker.patch("pygitgo.commands.git_operations._get_signing_flags", return_value=[])
+    fake_run = mocker.patch("pygitgo.commands.git_operations.run_command")
+    
+    fake_run.side_effect = ["M file.py", None]
+    git_commit("my message", skip_staging=True)
+
+    for call in fake_run.call_args_list:
+        args = call[0][0]
+        assert args[:2] != ["git", "add"], "git add should not run when skip_staging=True"
+
+def test_git_commit_default_runs_git_add(mocker):
+    mocker.patch("pygitgo.commands.git_operations._get_signing_flags", return_value=[])
+    fake_run = mocker.patch("pygitgo.commands.git_operations.run_command")
+    fake_run.side_effect = ["M file.py", None, None]
+    git_commit("my message")
+    add_call = fake_run.call_args_list[1][0][0]
+    assert add_call == ["git", "add", "."]

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,27 @@
+from pygitgo.main import link_operation
+
+
+def test_link_existing_repo_skips_staging(mocker):
+    mocker.patch('pygitgo.main.validate_repo_url', return_value=True)
+    mocker.patch('pygitgo.main.git_init', return_value=False)   
+    fake_commit = mocker.patch('pygitgo.main.git_commit')
+    mocker.patch('pygitgo.main.add_remote_origin')
+    mocker.patch('pygitgo.main.confirm_remote_link', return_value=True)
+    from argparse import Namespace
+    link_operation(Namespace(url="git@github.com:user/repo.git", message="init"))
+    fake_commit.assert_not_called()   
+    
+
+def test_link_new_repo_runs_commit(mocker):
+    mocker.patch('pygitgo.main.validate_repo_url', return_value=True)
+    mocker.patch('pygitgo.main.git_init', return_value=True)    
+    fake_commit = mocker.patch('pygitgo.main.git_commit', return_value=True)
+    mocker.patch('pygitgo.main.add_remote_origin')
+    mocker.patch('pygitgo.main.confirm_remote_link', return_value=True)
+    mocker.patch('pygitgo.main.get_current_branch', return_value='main')
+    mocker.patch('pygitgo.main.get_config', return_value='main')
+    mocker.patch('pygitgo.main.run_command', return_value='')
+    mocker.patch('builtins.input', return_value='n')
+    from argparse import Namespace
+    link_operation(Namespace(url="git@github.com:user/repo.git", message="init"))
+    fake_commit.assert_called_once()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,10 +5,6 @@ from pygitgo.commands.state import (
 import pytest
 
 
-# ---------------------------------------------------------------------------
-# validate_state_id
-# ---------------------------------------------------------------------------
-
 @pytest.mark.parametrize('state_id', ['1', '3', '11', '00002'])
 def test_validate_state_id(state_id, mocker):
     fake_error = mocker.patch('pygitgo.commands.state.error')
@@ -32,10 +28,6 @@ def test_validate_state_id_out_scope(state_id, mocker):
     assert result is False
     fake_error.assert_called_with("\nState ID out of range. Please enter a valid state ID.\n")
 
-
-# ---------------------------------------------------------------------------
-# all_save_state
-# ---------------------------------------------------------------------------
 
 def test_all_save_state_no_output(mocker):
     mocker.patch("pygitgo.commands.state.git_stash_list", return_value="")
@@ -79,10 +71,6 @@ def test_all_save_state_malformed_line(mocker):
     assert result[0]["message"] == "Another stash"
     fake_warning.assert_called_once_with("Skipping malformed line: malformed_line_here")
 
-
-# ---------------------------------------------------------------------------
-# load_state
-# ---------------------------------------------------------------------------
 
 def test_load_state_specific_id(mocker):
     save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg", "stash_index": 0}]
@@ -132,10 +120,6 @@ def test_load_state_no_args(mocker):
     fake_success.assert_called_once_with("\nState 'msg2' loaded successfully.\n")
 
 
-# ---------------------------------------------------------------------------
-# save_state
-# ---------------------------------------------------------------------------
-
 def test_save_state_no_args(mocker):
     mocker.patch("pygitgo.commands.state.run_command", return_value="M file")
     fake_push = mocker.patch(
@@ -163,10 +147,6 @@ def test_save_state_with_name(mocker):
     fake_push.assert_called_once_with(label="My-State")
     fake_success.assert_called_once_with("\nState 'My-State' saved successfully.\n")
 
-
-# ---------------------------------------------------------------------------
-# delete_state
-# ---------------------------------------------------------------------------
 
 def test_delete_state_all_confirm(mocker):
     mocker.patch("builtins.input", return_value="y")


### PR DESCRIPTION
## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal

## Overview
Fixed a bunch of control-flow bugs found during the audit. The main issue was commands running downstream steps (like `git add .`) unconditionally even when the parent step was skipped or failed. 

## Changes
- `gitgo link`: split into two explicit paths so we don't accidentally run `git add .` on existing repos with unwanted files.
- `gitgo push --select`: added a skip_staging flag so it actually respects your interactive selection instead of committing everything anyway.
- `gitgo user login`: added proper error raising for bad emails and missing `ssh-keygen` instead of just crashing.
- `gitgo user logout`: inverted the order so we try to delete files first. this stops your git config from being wiped if the file deletion fails.
- `gitgo jump`: wrapped the pull command in an else block so it stops trying to pull from main when you just created a brand new local branch.

## How to Test
1. `pip install -e ".[dev]"`
2. Run `gitgo push --select` and pick a few files. Verify that only those files got committed.
3. Run `gitgo jump new-test-branch`. Verify it checks out the branch without hanging to pull updates.
4. Expected result: Everything works cleanly without staging files you didn't ask for.

## Checklist
- [x] I tested my changes locally and they work
- [x] I updated `CHANGELOG.md` under the `[Unreleased]` section
- [ ] I updated `README.md` (if I added or changed a command)
- [x] I added or updated tests for my change (if applicable)
- [x] My change does not break any existing commands