### PR TITLE
chore: remove allow_fail flag and use exception-based architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Auto SSH Commit Signing:** GitGo now uses the SSH key generated during `gitgo user login` to automatically sign all commits using temporary `-c` flags, giving you the Verified badge on GitHub without modifying global git configs.
 
 ### Changed
+- Removed the `allow_fail` flag from `run_command` and switched to a robust `try/except` exception-based architecture to prevent silent failures.
 - Refactored CLI messaging to use a consistent tone, removing robotic phrases and filler words.
 - Standardized terminal output spacing and colors across all commands.
 - Updated success banners to a concise, military-style format for major operations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.7.0b4"
+version = "1.7.0b5"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/auth/account.py
+++ b/src/pygitgo/auth/account.py
@@ -1,19 +1,26 @@
 from pygitgo.utils.colors import info, success, warning, error, BLUE, RESET
-from pygitgo.utils.executor import run_command, command_failed
+from pygitgo.utils.executor import run_command
+from pygitgo.exceptions import GitCommandError
 
 
 def get_user():
     try:
-        name = run_command(["git", "config", "--global", "user.name"], allow_fail=True)
-        email = run_command(["git", "config", "--global", "user.email"], allow_fail=True)
+        name = run_command(["git", "config", "--global", "user.name"])
+    except GitCommandError:
+        name = None
+    
+    try:
+        email = run_command(["git", "config", "--global", "user.email"])
+    except GitCommandError:
+        email = None
+    
+    if not name:
+        name = None
+    if not email:
+        email = None
 
-        if not name or command_failed(name):
-            name = None
-        if not email or command_failed(email):
-            email = None
-        return name, email
-    except Exception:
-        return None, None
+    return name, email
+
     
 def set_user(name, email):
     run_command(["git", "config", "--global", "user.name", name])
@@ -58,3 +65,5 @@ def ensure_user_configure(default_email=None, default_username=None):
     
     error("Invalid configuration. Name and Email are required.")
     return False
+
+

--- a/src/pygitgo/auth/manager.py
+++ b/src/pygitgo/auth/manager.py
@@ -1,7 +1,9 @@
 from pygitgo.utils.colors import info, success, warning, error
 from pygitgo.utils.executor import run_command
+from pygitgo.exceptions import GitCommandError
 from . import ssh_utils
 import os
+
 
 def login():
     if ssh_utils.check_connection():
@@ -79,9 +81,16 @@ def logout():
         if os.path.exists(pub_key_path):
             os.remove(pub_key_path)
 
-        run_command(["git", "config", "--global", "--unset-all", "user.name"], allow_fail=True)
-        run_command(["git", "config", "--global", "--unset-all", "user.email"], allow_fail=True)
+        try:
+            run_command(["git", "config", "--global", "--unset-all", "user.name"])
+        except GitCommandError:
+            pass
         
+        try:
+            run_command(["git", "config", "--global", "--unset-all", "user.email"])
+        except GitCommandError:
+            pass
+
         success("User successfully logout")
         return True
     

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -1,7 +1,7 @@
-from pygitgo.utils import platform_utils
-from pygitgo.utils.colors import info, success, warning, error
-from pygitgo.utils.executor import run_command, command_failed
 from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.utils.colors import info, success, warning
+from pygitgo.utils.executor import run_command
+from pygitgo.utils import platform_utils
 from pathlib import Path
 import webbrowser
 import subprocess
@@ -26,16 +26,18 @@ def ensure_github_known_host():
         pass
 
     info("Adding GitHub to known_hosts...")
-    result = run_command(["ssh-keyscan", "-H", "github.com"], allow_fail=True, return_complete=True)
+    try:
+        result = run_command(["ssh-keyscan", "-H", "github.com"], return_complete=True)
     
-    if not command_failed(result) and result.stdout and "github.com" in result.stdout:
-        with open(known_hosts, "a") as f:
-            f.write(result.stdout)
-            if not result.stdout.endswith("\n"):
-                f.write("\n")
-        success("GitHub added to known_hosts.")
-    else:
+        if result.stdout and "github.com" in result.stdout:
+            with open(known_hosts, "a") as f:
+                f.write(result.stdout)
+                if not result.stdout.endswith("\n"):
+                    f.write("\n")
+            success("GitHub added to known_hosts.")
+    except GitCommandError:
         warning("Could not automatically add GitHub to known_hosts. You might be prompted.")
+
 
 def _get_github_ssh_response():
     try:
@@ -94,7 +96,7 @@ def generate_ssh_key(email):
             f"Details: {e}"
         )
     try:
-        run_command(["ssh-add", str(key_path)], allow_fail=True)
+        run_command(["ssh-add", str(key_path)])
     except (GitCommandError, OSError):
         pass 
     

--- a/src/pygitgo/commands/git_operations.py
+++ b/src/pygitgo/commands/git_operations.py
@@ -1,18 +1,21 @@
 from pygitgo.auth.ssh_utils import convert_https_to_ssh, get_ssh_key_path, is_ssh_url, check_connection
 from pygitgo.utils.colors import info, success, warning, error
-from pygitgo.utils.executor import run_command, command_failed
-from pygitgo.utils.config import get_config
 from pygitgo.exceptions import GitGoError, GitCommandError
+from pygitgo.utils.executor import run_command
+from pygitgo.utils.config import get_config
 from argparse import Namespace
-from pathlib import Path
 import os
 
 
 def get_status_content():
-    status = run_command(["git", "status", "--porcelain"], allow_fail=True)
-    if command_failed(status) or not status.strip():
+    try:
+        status = run_command(["git", "status", "--porcelain"])
+        if not status.strip():
+            raise GitGoError("Working tree is clean. Nothing to commit.")
+        return status
+    except GitCommandError:
         raise GitGoError("Working tree is clean. Nothing to commit.")
-    return status
+    
 
 def get_current_branch():
     branch = run_command(["git", "branch", "--show-current"]).strip()
@@ -21,31 +24,36 @@ def get_current_branch():
     return branch
 
 def get_main_branch():
-    main_branch = run_command(['git', 'remote', 'show', 'origin'], allow_fail=True)
     default_main_branch = get_config("default-branch", "main")
-    if command_failed(main_branch):
+
+    try:
+        output = run_command(['git', 'remote', 'show', 'origin'])
+    except GitCommandError:
         return default_main_branch
 
-    return main_branch.split("HEAD branch:")[-1].strip().splitlines()[0].strip() if "HEAD branch:" in main_branch else default_main_branch
+    if "HEAD branch:" not in output:
+        return default_main_branch
+
+    return output.split("HEAD branch:")[-1].strip().splitlines()[0].strip()
 
 def is_branch_exist(branch):
     return bool(run_command(["git", "branch", "-r", "--list", f"*/{branch}"])) or bool(run_command(["git", "branch", "--list", branch]))
 
 
 def git_new_branch(branch):
-    result = run_command(["git", "checkout", "-b", branch], loading_msg=f"Creating branch '{branch}'...")
-    if command_failed(result):
+    try:
+        run_command(["git", "checkout", "-b", branch], loading_msg=f"Creating branch '{branch}'...")
+        print()
+        success(f"Branch '{branch}' created.")
+    except GitCommandError:
         error(f"Failed to create branch '{branch}'! It may already exist.")
         choice = input("\nWould you like to jump to the existing branch instead? (y/n): ").strip().lower()
         if choice == "y":
-            from pygitgo.commands.jump import jump_operation
+            from pygitgo.commands.jump import jump_operation 
             jump_operation(Namespace(branch=branch))
         else:
             raise GitGoError(f"Operation canceled. Branch '{branch}' already exists.")
-    else:
-        print()
-        success(f"Branch '{branch}' created.")
-
+        
     return branch
 
 
@@ -59,8 +67,11 @@ def _get_signing_flags():
     ]
 
 def git_commit(commit_message, loading_msg="Commiting changes...", skip_staging=False):
-    status_result = run_command(["git", "status", "--porcelain"], allow_fail=True)
-    if command_failed(status_result) or not status_result.strip():
+    try:
+        status_result = run_command(["git", "status", "--porcelain"])
+        if not status_result.strip():
+            return False
+    except GitCommandError:
         return False
 
     if not skip_staging:
@@ -82,10 +93,11 @@ def git_init():
 
     default_main_branch = get_config("default-branch", "main")
 
-    result = run_command(["git", "init", "-b", default_main_branch], allow_fail=True, loading_msg="Initializing git repository...")
-    if command_failed(result):
+    try:
+        run_command(["git", "init", "-b", default_main_branch], loading_msg="Initializing git repository...")
+    except GitCommandError:
         run_command(["git", "init"], loading_msg="Initializing git repository...")
-        run_command(["git", "checkout", "-b", default_main_branch], allow_fail=True)
+        run_command(["git", "checkout", "-b", default_main_branch])
 
     success("Git repository initialized.")
     return True
@@ -94,32 +106,34 @@ def git_init():
 def add_remote_origin(repo_url):
     clean_url = repo_url.strip('"\'')
 
-    existing_remote = run_command(["git", "remote", "get-url", "origin"], allow_fail=True)
-    if not command_failed(existing_remote):
+    try:
+        existing_remote = run_command(["git", "remote", "get-url", "origin"])
         warning(f"Remote origin already exists: {existing_remote}")
         run_command(["git", "remote", "set-url", "origin", clean_url], loading_msg="Updating remote URL...")
-    else:
+    except GitCommandError:
         run_command(["git", "remote", "add", "origin", clean_url], loading_msg="Adding remote origin...")
 
     success(f"Remote origin set to: {clean_url}")
 
 
 def confirm_remote_link():
-    test_result = run_command(["git", "ls-remote", "origin"], allow_fail=True, loading_msg="Testing connection to remote...")
-
-    if command_failed(test_result):
+    try:
+        run_command(["git", "ls-remote", "origin"], loading_msg="Testing connection to remote...")
+        success("Remote is reachable.")
+        return True
+    except GitCommandError:
         error("Connection failed — verify the URL and your SSH key.")
         info("Run:  git remote -v   to inspect your current remote.")
         return False
 
-    success("Remote is reachable.")
-    return True
-
 
 def create_main_branch():
-    current_branch = run_command(["git", "branch", "--show-current"], allow_fail=True)
+    try:
+        current_branch = run_command(["git", "branch", "--show-current"])
+    except GitCommandError:
+        current_branch = None
 
-    if command_failed(current_branch) or not current_branch.strip():
+    if not current_branch or not current_branch.strip():
         run_command(["git", "checkout", "-b", "main"], loading_msg="Setting default branch to 'main'...")
     elif current_branch.strip() != "main":
         run_command(["git", "branch", "-m", "main"], loading_msg=f"Renaming branch '{current_branch.strip()}' to 'main'...")
@@ -156,16 +170,16 @@ def check_and_sync_branch(branch):
 
 
 def git_push(branch):
-    remote_url = run_command(["git", "remote", "get-url", "origin"], allow_fail=True)
+    try:
+        remote_url = run_command(["git", "remote", "get-url", "origin"]).strip()
+    except GitCommandError:
+        remote_url = None
 
-    if not command_failed(remote_url) and remote_url:
-        remote_url = remote_url.strip()
-
-        if not is_ssh_url(remote_url) and check_connection():
-            ssh_url = convert_https_to_ssh(remote_url)
-            if ssh_url:
-                run_command(["git", "remote", "set-url", "origin", ssh_url], loading_msg="Converting remote from HTTPS to SSH for secure push...")
-                success(f"Remote updated to: {ssh_url}")
+    if remote_url and not is_ssh_url(remote_url) and check_connection():
+        ssh_url = convert_https_to_ssh(remote_url)
+        if ssh_url:
+            run_command(["git", "remote", "set-url", "origin", ssh_url], loading_msg="Converting remote from HTTPS to SSH for secure push...")
+            success(f"Remote updated to: {ssh_url}")
 
     try:
         run_command(["git", "push", "-u", "origin", branch], loading_msg=f"Pushing to remote branch '{branch}'...")
@@ -175,20 +189,15 @@ def git_push(branch):
         if "rebase in progress" in str(e):
             handle_rebase()
         else:
-            raise GitGoError("Push failed — see above.")
+            raise GitGoError("Push failed - see above.")
 
 
 def handle_rebase():
-    status = run_command(["git", "status"], allow_fail=True)
-    if command_failed(status):
-        return False
+    warning("Conflict detected during rebase.")
+    info("Resolve conflicts manually, then run:")
+    info("    git add <files>")
+    info("    git rebase --continue")
+    info("When finished, run 'gitgo push <branch> <message>' again.")
+    raise GitGoError("Push aborted — rebase conflict in progress.")
 
-    if "rebase in progress" in status or "rebase" in status.lower():
-        warning("Conflict detected during rebase.")
-        info("Resolve conflicts manually, then run:")
-        info("    git add <files>")
-        info("    git rebase --continue")
-        info("When finished, run 'gitgo push <branch> <message>' again.")
-        raise GitGoError("Push aborted — rebase conflict in progress.")
-
-    return True
+    

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -5,15 +5,18 @@ from pygitgo.commands.stash_operation import (
     git_stash_pop, git_stash_push, git_stash_apply, git_stash_drop
 )
 from pygitgo.utils.colors import warning, info, success, error
-from pygitgo.utils.executor import run_command, command_failed
-from pygitgo.exceptions import GitGoError
+from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.utils.executor import run_command
 from json import load
 
 
 def undo_jump_operation(original_branch, stashed_code, created_branch=None):
     if created_branch:
         run_command(["git", "checkout", original_branch], loading_msg=f"Jumping you back to the original branch '{original_branch}'...")
-        run_command(["git", "branch", "-D", created_branch], allow_fail=True, loading_msg=f"Removing the empty branch '{created_branch}'...")
+        try:
+            run_command(["git", "branch", "-D", created_branch], loading_msg=f"Removing the empty branch '{created_branch}'...")
+        except GitCommandError:
+            warning(f"Could not delete branch '{created_branch}'. Remove it manually with: git branch -D {created_branch}")
     else:
         run_command(["git", "reset", "--hard", "HEAD"], loading_msg="Canceling... Putting your files back exactly how they were...")
         run_command(['git', 'checkout', original_branch], loading_msg=f"Jumping you back to the original branch '{original_branch}'...")
@@ -38,8 +41,9 @@ def jump_operation(args):
         warning(f"Already on branch '{target_branch}'.")
         return
 
-    has_changes = run_command(['git', 'status', '--porcelain'], allow_fail=True, loading_msg="Checking for uncommitted changes...")
-    if command_failed(has_changes):
+    try:
+        has_changes = run_command(['git', 'status', '--porcelain'], loading_msg="Checking for uncommitted changes...")
+    except GitCommandError:
         raise GitGoError("Unable to check for uncommitted changes — make sure you're in a valid git repository.")
 
     stashed_code = False
@@ -80,9 +84,10 @@ def jump_operation(args):
         run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...")
 
         main_branch = get_main_branch()
-        get_origin_updates = run_command(['git', 'pull', 'origin', main_branch], allow_fail=True, loading_msg=f"Downloading the latest updates from '{main_branch}'...")
 
-        if command_failed(get_origin_updates):
+        try:
+            run_command(['git', 'pull', 'origin', main_branch], loading_msg=f"Downloading the latest updates from '{main_branch}'...")
+        except GitCommandError:
             warning(f"Failed to pull updates from '{main_branch}'. No internet, or the remote branch doesn't exist yet.")
             user_input = input("Stay on the new branch without the latest updates? (y/n): ").strip().lower()
             if user_input != 'y':
@@ -122,3 +127,5 @@ def jump_operation(args):
         print()
         success(f"On '{target_branch}'.")
         return
+    
+

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -1,0 +1,89 @@
+from pygitgo.commands.git_operations import (
+    git_init, git_commit, git_push, add_remote_origin,
+    confirm_remote_link, get_current_branch
+)
+from pygitgo.utils.config import get_config
+from pygitgo.utils.executor import run_command
+from pygitgo.utils.colors import success, warning, error, highlight, print_banner
+from pygitgo.exceptions import GitCommandError, GitGoError
+import re
+
+
+def validate_repo_url(url):
+    """Validate that the URL looks like a valid Git repository URL."""
+    patterns = [
+        r'^https?://[\w.-]+/[\w.-]+/[\w.-]+(?:\.git)?/?$',  # HTTPS
+        r'^git@[\w.-]+:[\w.-]+/[\w.-]+(?:\.git)?$',          # SSH
+    ]
+    return any(re.match(p, url.strip()) for p in patterns)
+
+
+def link_operation(args):
+    repo_url = args.url
+
+    if not validate_repo_url(repo_url):
+        raise GitGoError(
+            "\nInvalid repository URL!\n"
+            "Expected format: https://github.com/username/repo.git"
+            "             or: git@github.com:username/repo.git\n"
+        )
+
+    commit_message = args.message
+    
+    highlight("INITIATING LINK OPERATION...")
+    highlight(f"Target: {repo_url}")
+    print()
+    
+    is_new_repo = git_init()
+    
+    if not is_new_repo:
+        add_remote_origin(repo_url)
+
+        if confirm_remote_link():
+            success("\nRemote linked to existing repository.")
+            success(f"Ready to push with: gitgo push <branch> 'your message'\n")
+        return
+
+    commit_made = git_commit(commit_message, loading_msg="Creating initial commit...")
+    if commit_made:
+        success("Initial commit created.")
+    
+    add_remote_origin(repo_url)
+    
+    if not confirm_remote_link():
+        return
+    
+    current_branch = get_current_branch()
+    main_branch = get_config("default-branch", "main")
+    
+    if current_branch != main_branch:
+        run_command(["git", "branch", "-m", main_branch], loading_msg=f"Renaming branch '{current_branch}' to '{main_branch}'...")
+        current_branch = main_branch
+        
+    try:
+        remote_refs = run_command(["git", "ls-remote", "--heads", "origin", main_branch], loading_msg="Checking remote branches...")
+    except GitCommandError:
+        remote_refs = None
+
+    if remote_refs and remote_refs.strip():
+        try:
+            run_command(
+                ["git", "pull", "origin", main_branch, "--allow-unrelated-histories", "--no-edit"],
+                loading_msg="Pulling and merging remote content..."
+            )
+            success("Remote content merged.")
+        except GitCommandError:
+            error("Failed to merge remote content. You may need to resolve conflicts manually.")
+            warning(f"Run: git pull origin {main_branch} --allow-unrelated-histories")
+            warning(f"Then: gitgo push {main_branch} 'your message'\n")
+            return
+    
+    print_banner("REPOSITORY INITIALIZED AND LINKED.")
+
+    user_choice = input(f"Do you want to push now? (y/n): ").lower()
+    if user_choice != 'y':
+        return
+
+    git_push(current_branch)
+
+    print_banner("REPOSITORY INITIALIZED AND DEPLOYED.")

--- a/src/pygitgo/commands/pull.py
+++ b/src/pygitgo/commands/pull.py
@@ -1,7 +1,7 @@
 from pygitgo.commands.git_operations import get_current_branch
 from pygitgo.utils.colors import success, warning, error, info
 from pygitgo.exceptions import GitCommandError, GitGoError
-from pygitgo.utils.executor import run_command, command_failed
+from pygitgo.utils.executor import run_command
 
 
 def pull_operation(args):
@@ -12,8 +12,9 @@ def pull_operation(args):
         info(f"No branch provided. Pulling latest updates for '{branch}'...")
 
     try:
-        remote_refs = run_command(["git", "ls-remote", "--heads", "origin", branch], allow_fail=True)
-        if command_failed(remote_refs) or not remote_refs.strip():
+        try:
+            run_command(["git", "ls-remote", "--heads", "origin", branch])
+        except GitCommandError:
             error(f"Branch '{branch}' does not exist on the remote.")
             info("Push your local branch first, or verify the branch name.")
             raise GitGoError("Pull aborted — branch not found on remote.")

--- a/src/pygitgo/commands/push.py
+++ b/src/pygitgo/commands/push.py
@@ -1,0 +1,84 @@
+from pygitgo.commands.git_operations import (
+    git_new_branch, git_commit, git_push, get_current_branch, is_branch_exist
+)
+from pygitgo.commands.staging import get_changed_files, display_file_picker, selective_stage
+from pygitgo.commands.jump import jump_operation
+from pygitgo.utils.config import get_config
+from pygitgo.utils.executor import run_command
+from pygitgo.utils.colors import info, warning, error, print_banner
+from pygitgo.exceptions import GitCommandError, GitGoError
+from argparse import Namespace
+
+
+def push_operation(args):
+    branch = args.branch
+    message = args.message
+    select = args.select if hasattr(args, 'select') else False
+
+    if args.new:
+        if not branch:
+            raise GitGoError("\nBranch name required when using --new flag!\n")
+        git_new_branch(branch)
+    else:
+        if branch and not message and not is_branch_exist(branch):
+            message = branch
+            branch = get_current_branch()
+            info(f"No branch name provided. Using current branch: '{branch}'\n")
+            
+        elif branch and is_branch_exist(branch):
+            current_branch = get_current_branch()
+            if current_branch != branch:
+                warning(f"You are currently on branch '{current_branch}', not '{branch}'.")
+                user_choice = input(f"Do you want to switch to branch '{branch}'? (y/n): ").lower()
+                if user_choice != 'y':
+                    raise GitGoError("\nPush aborted to prevent committing to the wrong branch.\n")
+                jump_operation(Namespace(branch=branch))
+    
+        elif not branch:
+            branch = get_current_branch()
+
+    if not message:
+        message = get_config("default-message", "New Project Update")
+        info(f"No commit message provided. Using default: '{message}'\n")
+
+    if select:
+        files = get_changed_files()
+        if not files:
+            info("\nWorking tree is clean. Nothing to select.")
+            warning("Make some changes first before using GitGo to commit and push.")
+            return
+
+        selected = display_file_picker(files)
+        if not selected:
+            info("\nNo files selected. Push aborted.\n")
+            return
+
+        selective_stage(selected)
+        commit_made = git_commit(message, loading_msg="Commiting selected files...", skip_staging=True)
+        
+        if commit_made:
+            git_push(branch)
+        
+    else:
+        commit_made = git_commit(message)
+        
+        if commit_made:
+            git_push(branch)
+        else:
+            try:
+                unpushed = run_command(["git", "log", "--oneline", f"origin/{branch}..HEAD"], loading_msg="Checking for unpushed commits...")
+
+                if unpushed.strip():
+                    warning("\nNo changes to commit, but found unpushed commits. Pushing to remote...")
+                    git_push(branch)
+                else:
+                    info("\nWorking tree is clean and everything is up to date.")
+                    warning("Make some changes first before using GitGo to commit and push.")
+                    return
+                
+            except (GitCommandError, Exception):
+                warning("\nNo changes to commit. Cannot verify remote status.")
+                warning("Make some changes first or check your git remote configuration.")
+                return
+
+    print_banner("MISSION COMPLETE. ALL TARGETS COMMITTED AND PUSHED.")

--- a/src/pygitgo/commands/staging.py
+++ b/src/pygitgo/commands/staging.py
@@ -1,5 +1,6 @@
 from pygitgo.utils.colors import success, warning, error
-from pygitgo.utils.executor import run_command, command_failed
+from pygitgo.utils.executor import run_command
+from pygitgo.exceptions import GitCommandError
 from pick import pick
 
 
@@ -13,10 +14,11 @@ STATUS_LABELS = {
 
 
 def get_changed_files():
-    status = run_command(["git", "status", "--porcelain"], allow_fail=True)
-    if command_failed(status) or not status.strip():
+    try:
+        status = run_command(["git", "status", "--porcelain"])
+    except GitCommandError:
         return []
-
+    
     files = []
     for line in status.strip().splitlines():
         if len(line) < 3:
@@ -27,7 +29,6 @@ def get_changed_files():
         files.append({"status": status_code, "label": label, "path": filepath})
 
     return files
-
 
 def display_file_picker(files):
     options = [f"({f['label']}) {f['path']}" for f in files]

--- a/src/pygitgo/commands/stash_operation.py
+++ b/src/pygitgo/commands/stash_operation.py
@@ -1,49 +1,69 @@
-from pygitgo.utils.executor import command_failed, run_command
-
+from pygitgo.utils.executor import run_command
+from pygitgo.exceptions import GitCommandError
 
 def git_stash_push(label="GitGo Auto-Stash", loading_msg="Saving your changes..."):
-    result = run_command(
-        ["git", "stash", "push", "-u", "-m", label],
-        allow_fail=True,
-        loading_msg=loading_msg
-    )
-    if command_failed(result):
+    try:
+        result = run_command(
+            ["git", "stash", "push", "-u", "-m", label],
+            loading_msg=loading_msg
+        )
+
+        if isinstance(result, str) and "No local changes to save" in result:
+            return False
+        
+        return True
+
+    except GitCommandError:
         return False
-    if isinstance(result, str) and "No local changes to save" in result:
-        return False
-    return True
+    
 
 def git_stash_pop(loading_msg="Restoring your saved changes..."):
-    result = run_command(
-        ["git", "stash", "pop"], 
-        allow_fail=True, 
-        loading_msg=loading_msg
-    )
-    return not command_failed(result)
+    try:
+        run_command(
+            ["git", "stash", "pop"], 
+            loading_msg=loading_msg
+        )
+        return True
+    except GitCommandError:
+        return False
+
 
 def git_stash_apply(stash_id=None, loading_msg="Applying saved changes..."):
     command = ["git", "stash", "apply"]
     if stash_id is not None:
         command.append(f"stash@{{{stash_id}}}")
 
-    result = run_command(command, allow_fail=True, loading_msg=loading_msg)
-    return not command_failed(result)
+    try:
+        run_command(command, loading_msg=loading_msg)
+        return True
+    except GitCommandError:
+        return False
+
 
 def git_stash_drop(stash_id=None, loading_msg="Cleaning up stash..."):
     command = ["git", "stash", "drop"]
     if stash_id is not None:
         command.append(f"stash@{{{stash_id}}}")
 
-    result = run_command(command, allow_fail=True, loading_msg=loading_msg)
-    return not command_failed(result)
+    try:
+        run_command(command, loading_msg=loading_msg)
+        return True
+    except GitCommandError:
+        return False
 
 def git_stash_list(loading_msg="Fetching stash list..."):
-    return run_command([
-        "git", "stash", "list",
-        "--date=format:%Y-%m-%d %H:%M:%S",
-        "--pretty=%gd||%cd||%s"
-    ], allow_fail=True, loading_msg=loading_msg)
+    try:
+        return run_command([
+            "git", "stash", "list",
+            "--date=format:%Y-%m-%d %H:%M:%S",
+            "--pretty=%gd||%cd||%s"
+        ], loading_msg=loading_msg)
+    except GitCommandError:
+        return ""
 
 def git_stash_clear(loading_msg="Clearing all stashes..."):
-    result = run_command(["git", "stash", "clear"], allow_fail=True, loading_msg=loading_msg)
-    return not command_failed(result)
+    try:
+        run_command(["git", "stash", "clear"], loading_msg=loading_msg)
+        return True
+    except GitCommandError:
+        return False

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -3,15 +3,17 @@ from pygitgo.commands.stash_operation import (
     git_stash_apply, git_stash_clear, git_stash_drop,
     git_stash_list, git_stash_push
 )
-from pygitgo.utils.executor import run_command, command_failed
-from pygitgo.exceptions import GitGoError
+from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.utils.executor import run_command
 
 
 
 def all_save_state():
-    output = git_stash_list()
-
-    if command_failed(output) or not output:
+    try:
+        output = git_stash_list()
+        if not output:
+            return []
+    except GitCommandError:
         return []
 
     save_states = []
@@ -132,8 +134,13 @@ def save_state(state_name=None):
     if not state_name:
         state_name = "Auto-Save"
 
-    has_changes = run_command(['git', 'status', '--porcelain'], allow_fail=True)
-    if not command_failed(has_changes) and not has_changes.strip():
+    try:
+        has_changes = run_command(['git', 'status', '--porcelain'])
+    except GitCommandError:
+        warning("Could not check for local changes - make sure you're in a valid git repository.")
+        return
+    
+    if not has_changes.strip():
         info("No local changes to save.")
         return
 

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -1,175 +1,18 @@
-from pygitgo.commands.git_operations import (
-    git_new_branch, git_commit, git_init, add_remote_origin,
-    confirm_remote_link, git_push, get_current_branch, is_branch_exist
-)
-from pygitgo.commands.staging import get_changed_files, display_file_picker, selective_stage
 from pygitgo.utils.update_checker import check_for_updates_background
-from pygitgo.utils.executor import run_command, command_failed
-from pygitgo.utils.colors import info, success, warning, error, highlight, print_banner
-from pygitgo.utils.config import get_config, config_operation
-from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.utils.colors import info, warning, error
+from pygitgo.utils.config import config_operation
+from pygitgo.exceptions import GitGoError
 from pygitgo.utils.setup import ensure_first_run_setup
 from pygitgo.commands.state import state_operations
 from pygitgo.commands.undo import undo_operations
 from pygitgo.commands.pull import pull_operation
 from pygitgo.commands.jump import jump_operation
+from pygitgo.commands.link import link_operation
+from pygitgo.commands.push import push_operation
 from pygitgo.auth.manager import login, logout
 from pygitgo.auth.account import get_user
-from argparse import Namespace
 import argparse
 import sys
-import re
-
-
-
-
-
-def validate_repo_url(url):
-    """Validate that the URL looks like a valid Git repository URL."""
-    patterns = [
-        r'^https?://[\w.-]+/[\w.-]+/[\w.-]+(?:\.git)?/?$',  # HTTPS
-        r'^git@[\w.-]+:[\w.-]+/[\w.-]+(?:\.git)?$',          # SSH
-    ]
-    return any(re.match(p, url.strip()) for p in patterns)
-
-
-def link_operation(args):
-    repo_url = args.url
-
-    if not validate_repo_url(repo_url):
-        raise GitGoError(
-            "\nInvalid repository URL!\n"
-            "Expected format: https://github.com/username/repo.git"
-            "             or: git@github.com:username/repo.git\n"
-        )
-
-    commit_message = args.message
-    
-    highlight("INITIATING LINK OPERATION...")
-    highlight(f"Target: {repo_url}")
-    print()
-    
-    is_new_repo = git_init()
-    
-    if not is_new_repo:
-        add_remote_origin(repo_url)
-
-        if confirm_remote_link():
-            success("\nRemote linked to existing repository.")
-            success(f"Ready to push with: gitgo push <branch> 'your message'\n")
-        return
-
-    commit_made = git_commit(commit_message, loading_msg="Creating initial commit...")
-    if commit_made:
-        success("Initial commit created.")
-    
-    add_remote_origin(repo_url)
-    
-    if not confirm_remote_link():
-        return
-    
-    current_branch = get_current_branch()
-    main_branch = get_config("default-branch", "main")
-    
-    if current_branch != main_branch:
-        run_command(["git", "branch", "-m", main_branch], loading_msg=f"Renaming branch '{current_branch}' to '{main_branch}'...")
-        current_branch = main_branch
-    
-    remote_refs = run_command(["git", "ls-remote", "--heads", "origin", main_branch], allow_fail=True, loading_msg="Checking remote branches...")
-    if not command_failed(remote_refs) and remote_refs.strip():
-        pull_result = run_command(
-            ["git", "pull", "origin", main_branch, "--allow-unrelated-histories", "--no-edit"],
-            allow_fail=True, loading_msg="Pulling and merging remote content..."
-        )
-        if command_failed(pull_result):
-            error("Failed to merge remote content. You may need to resolve conflicts manually.")
-            warning(f"Run: git pull origin {main_branch} --allow-unrelated-histories")
-            warning(f"Then: gitgo push {main_branch} 'your message'\n")
-            return
-        success("Remote content merged.")
-    
-    print_banner("REPOSITORY INITIALIZED AND LINKED.")
-
-    user_choice = input(f"Do you want to push now? (y/n): ").lower()
-    if user_choice != 'y':
-        return
-
-    git_push(current_branch)
-
-    print_banner("REPOSITORY INITIALIZED AND DEPLOYED.")
-    
-
-def push_operation(args):
-    branch = args.branch
-    message = args.message
-    select = args.select if hasattr(args, 'select') else False
-
-    if args.new:
-        if not branch:
-            raise GitGoError("\nBranch name required when using --new flag!\n")
-        git_new_branch(branch)
-    else:
-        if branch and not message and not is_branch_exist(branch):
-            message = branch
-            branch = get_current_branch()
-            info(f"No branch name provided. Using current branch: '{branch}'\n")
-            
-        elif branch and is_branch_exist(branch):
-            current_branch = get_current_branch()
-            if current_branch != branch:
-                warning(f"You are currently on branch '{current_branch}', not '{branch}'.")
-                user_choice = input(f"Do you want to switch to branch '{branch}'? (y/n): ").lower()
-                if user_choice != 'y':
-                    raise GitGoError("\nPush aborted to prevent committing to the wrong branch.\n")
-                jump_operation(Namespace(branch=branch))
-    
-        elif not branch:
-            branch = get_current_branch()
-
-    if not message:
-        message = get_config("default-message", "New Project Update")
-        info(f"No commit message provided. Using default: '{message}'\n")
-
-    if select:
-        files = get_changed_files()
-        if not files:
-            info("\nWorking tree is clean. Nothing to select.")
-            warning("Make some changes first before using GitGo to commit and push.")
-            return
-
-        selected = display_file_picker(files)
-        if not selected:
-            info("\nNo files selected. Push aborted.\n")
-            return
-
-        selective_stage(selected)
-        commit_made = git_commit(message, loading_msg="Commiting selected files...", skip_staging=True)
-        
-        if commit_made:
-            git_push(branch)
-        
-    else:
-        commit_made = git_commit(message)
-        
-        if commit_made:
-            git_push(branch)
-        else:
-            try:
-                unpushed = run_command(["git", "log", "--oneline", f"origin/{branch}..HEAD"], allow_fail=True, loading_msg="Checking for unpushed commits...")
-                if not command_failed(unpushed) and unpushed.strip():
-                    warning("\nNo changes to commit, but found unpushed commits. Pushing to remote...")
-                    git_push(branch)
-                else:
-                    info("\nWorking tree is clean and everything is up to date.")
-                    warning("Make some changes first before using GitGo to commit and push.")
-                    return
-            except (GitCommandError, Exception):
-                warning("\nNo changes to commit. Cannot verify remote status.")
-                warning("Make some changes first or check your git remote configuration.")
-                return
-
-    print_banner("MISSION COMPLETE. ALL TARGETS COMMITTED AND PUSHED.")
-
 
 def display_current_user():
     import shutil

--- a/src/pygitgo/utils/config.py
+++ b/src/pygitgo/utils/config.py
@@ -1,31 +1,30 @@
-from pygitgo.utils.executor import command_failed, run_command
+from pygitgo.utils.executor import run_command
 from pygitgo.utils.colors import error, warning, success, info
+from pygitgo.exceptions import GitCommandError
 
 
 def get_config(key, fallback_value):
 
     config_key = f"gitgo.{key}"
 
-    result = run_command(['git', 'config', '--global', config_key], allow_fail=True)                                                                                                                     
-
-    if not result or command_failed(result):
+    try:
+        result = run_command(['git', 'config', '--global', config_key])                                                                                                                     
+        return result.strip()
+    except GitCommandError:
         return fallback_value
-
-    return result.strip()
 
 
 def set_config(key, value):
 
     config_key = f"gitgo.{key}"
 
-    result = run_command(['git', 'config', '--global', config_key, value], allow_fail=True)
-    
-    if command_failed(result):
+    try:
+        result = run_command(['git', 'config', '--global', config_key, value])
+        success(f"\nConfiguration saved: {key} = '{value}'")
+        return True
+    except GitCommandError:
         error(f"\nFailed to save configuration for '{key}'.")
         return False 
-
-    success(f"\nConfiguration saved: {key} = '{value}'")
-    return True
 
 
 def config_operation(args):

--- a/src/pygitgo/utils/executor.py
+++ b/src/pygitgo/utils/executor.py
@@ -6,16 +6,7 @@ import os
 import re
 
 
-def run_command(command, allow_fail=False, return_complete=False, loading_msg=None):
-    """
-    Runs a shell command safely.
-
-    :param command: list of command + args
-    :param allow_fail: if True, do not raise on error
-    :param return_complete: if True, return subprocess.CompletedProcess instead of stdout
-    :param loading_msg: if provided, show a yaspin spinner with this message
-    :raises GitCommandError: when the command fails and allow_fail is False
-    """
+def run_command(command, return_complete=False, loading_msg=None):
 
     spinner = yaspin(text=loading_msg, color="cyan") if loading_msg else None
 
@@ -64,17 +55,10 @@ def run_command(command, allow_fail=False, return_complete=False, loading_msg=No
                 try:
                     subprocess.run(fix_command, check=True)
                     success("Directory trusted. Retrying command...")
-                    return run_command(command, allow_fail, return_complete, loading_msg=loading_msg)
+                    return run_command(command, return_complete, loading_msg=loading_msg)
                 except OSError as fix_err:
                     error(f"Failed to apply fix: {fix_err}")
             else:
                 warning("Fix declined. Operations in this directory will continue to fail.")
 
-        if allow_fail:
-            return e
-
         raise GitCommandError(command, stderr=stderr, returncode=returncode)
-
-def command_failed(result):
-    # Returns True if run_command had error
-    return isinstance(result, Exception)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,74 @@
+import pytest
+from pygitgo.exceptions import GitCommandError
+from pygitgo.auth.account import get_user, set_user, ensure_user_configure
+
+
+def test_get_user_both_exist(mocker):
+    fake_run = mocker.patch("pygitgo.auth.account.run_command", side_effect=["John Doe", "john@example.com"])
+    name, email = get_user()
+    assert name == "John Doe"
+    assert email == "john@example.com"
+    assert fake_run.call_count == 2
+
+
+def test_get_user_none_exist(mocker):
+    fake_run = mocker.patch("pygitgo.auth.account.run_command", side_effect=GitCommandError(["git", "config"]))
+    name, email = get_user()
+    assert name is None
+    assert email is None
+    assert fake_run.call_count == 2
+
+
+def test_set_user(mocker):
+    fake_run = mocker.patch("pygitgo.auth.account.run_command")
+    fake_success = mocker.patch("pygitgo.auth.account.success")
+
+    set_user("Alice", "alice@example.com")
+
+    fake_run.assert_any_call(["git", "config", "--global", "user.name", "Alice"])
+    fake_run.assert_any_call(["git", "config", "--global", "user.email", "alice@example.com"])
+    fake_success.assert_called_once()
+
+
+def test_ensure_user_configure_already_exists(mocker):
+    mocker.patch("pygitgo.auth.account.get_user", return_value=("John Doe", "john@example.com"))
+    fake_set = mocker.patch("pygitgo.auth.account.set_user")
+
+    result = ensure_user_configure()
+    assert result is True
+    fake_set.assert_not_called()
+
+
+def test_ensure_user_configure_defaults_exist(mocker):
+    mocker.patch("pygitgo.auth.account.get_user", return_value=(None, None))
+    fake_set = mocker.patch("pygitgo.auth.account.set_user")
+    mocker.patch("pygitgo.auth.account.info")
+
+    result = ensure_user_configure(default_email="git@github.com", default_username="GithubUser")
+    assert result is True
+    fake_set.assert_called_once_with("GithubUser", "git@github.com")
+
+
+def test_ensure_user_configure_prompt_success(mocker):
+    mocker.patch("pygitgo.auth.account.get_user", return_value=(None, None))
+    fake_set = mocker.patch("pygitgo.auth.account.set_user")
+    mocker.patch("pygitgo.auth.account.info")
+    mocker.patch("pygitgo.auth.account.warning")
+    mocker.patch("builtins.input", side_effect=["John Doe", "john@example.com"])
+
+    result = ensure_user_configure()
+    assert result is True
+    fake_set.assert_called_once_with("John Doe", "john@example.com")
+
+
+def test_ensure_user_configure_prompt_failure(mocker):
+    mocker.patch("pygitgo.auth.account.get_user", return_value=(None, None))
+    fake_set = mocker.patch("pygitgo.auth.account.set_user")
+    mocker.patch("pygitgo.auth.account.info")
+    mocker.patch("pygitgo.auth.account.warning")
+    mocker.patch("pygitgo.auth.account.error")
+    mocker.patch("builtins.input", side_effect=["", ""])
+
+    result = ensure_user_configure()
+    assert result is False
+    fake_set.assert_not_called()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,8 @@ import subprocess
 
 
 def test_get_config_fallback(mocker):
-    fake_run = mocker.patch('pygitgo.utils.config.run_command', return_value="")
+    from pygitgo.exceptions import GitCommandError
+    fake_run = mocker.patch('pygitgo.utils.config.run_command', side_effect=GitCommandError(['git']))
 
     fallback_value = "false"
 
@@ -21,7 +22,8 @@ def test_get_config_ok(mocker):
     assert result != fallback_value
 
 def test_set_config_fallback(mocker):
-    fake_run = mocker.patch('pygitgo.utils.config.run_command', return_value=subprocess.CalledProcessError(1, 'git'))
+    from pygitgo.exceptions import GitCommandError
+    fake_run = mocker.patch('pygitgo.utils.config.run_command', side_effect=GitCommandError(['git']))
     fake_error = mocker.patch('pygitgo.utils.config.error')
 
     key = 'default-key'
@@ -67,7 +69,8 @@ def test_get_config_strip(mocker):
     assert result == "true"
 
 def test_get_config_error_handling(mocker):
-    fake_run = mocker.patch('pygitgo.utils.config.run_command', return_value=subprocess.CalledProcessError(1, 'git'))
+    from pygitgo.exceptions import GitCommandError
+    fake_run = mocker.patch('pygitgo.utils.config.run_command', side_effect=GitCommandError(['git']))
     result = get_config("default-key", "fallback")
     assert result == "fallback"
 

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -22,7 +22,8 @@ def test_git_branch_logic(mocker):
     )
 
 def test_git_branch_exists_jump_yes(mocker):
-    fake_run = mocker.patch("pygitgo.commands.git_operations.run_command", return_value=subprocess.CalledProcessError(1, 'git'))
+    from pygitgo.exceptions import GitCommandError
+    fake_run = mocker.patch("pygitgo.commands.git_operations.run_command", side_effect=GitCommandError(["git", "checkout", "-b"]))
     mocker.patch("builtins.input", return_value="y")
     fake_jump = mocker.patch("pygitgo.commands.jump.jump_operation")
     fake_error = mocker.patch("pygitgo.commands.git_operations.error")
@@ -37,14 +38,14 @@ def test_git_branch_exists_jump_yes(mocker):
     assert args.branch == branch_name
 
 def test_git_branch_exists_jump_no(mocker):
-    fake_run = mocker.patch("pygitgo.commands.git_operations.run_command", return_value=subprocess.CalledProcessError(1, 'git'))
+    from pygitgo.exceptions import GitCommandError, GitGoError
+    fake_run = mocker.patch("pygitgo.commands.git_operations.run_command", side_effect=GitCommandError(["git", "checkout", "-b"]))
     mocker.patch("builtins.input", return_value="n")
     fake_jump = mocker.patch("pygitgo.commands.jump.jump_operation")
     fake_error = mocker.patch("pygitgo.commands.git_operations.error")
 
     branch_name = "existing-branch"
     
-    from pygitgo.exceptions import GitGoError
     with pytest.raises(GitGoError):
         git_new_branch(branch_name)
     fake_error.assert_called_once_with(f"Failed to create branch '{branch_name}'! It may already exist.")
@@ -95,30 +96,35 @@ def test_git_init_success(mocker):
     fake_success.assert_called_once()
     fake_run.assert_called_once_with(
         ["git", "init", "-b", 'main'], 
-        allow_fail=True, 
         loading_msg="Initializing git repository..."
     )
 
 def test_git_init_fallback(mocker):
+    from pygitgo.exceptions import GitCommandError
     mocker.patch('os.path.isdir', return_value=False)
     mocker.patch('pygitgo.commands.git_operations.get_config', return_value='main')
     fake_success = mocker.patch('pygitgo.commands.git_operations.success')
     
     fake_run = mocker.patch(
         'pygitgo.commands.git_operations.run_command', 
-        return_value=subprocess.CalledProcessError(1, 'git')
+        side_effect=[
+            GitCommandError(["git", "init", "-b", "main"]),
+            "init_success",
+            "checkout_success"
+        ]
     )
 
     result = git_init()
 
     assert result == True
     fake_success.assert_called_once()
-    fake_run.call_count == 3
+    assert fake_run.call_count == 3
 
 def test_create_main_branch_no_branch(mocker):
+    from pygitgo.exceptions import GitCommandError
     fake_run = mocker.patch(
         'pygitgo.commands.git_operations.run_command',
-        return_value=subprocess.CalledProcessError(1, 'git')
+        side_effect=[GitCommandError(["git", "branch"]), "ok"]
     )
 
     create_main_branch()
@@ -162,63 +168,36 @@ def test_confirm_remote_link_success(mocker):
     assert result == True
 
     fake_run.assert_called_once_with(
-        ["git", "ls-remote", "origin"], allow_fail=True, 
+        ["git", "ls-remote", "origin"], 
         loading_msg="Testing connection to remote..."
     )
 
 def test_confirm_remote_link_fallback(mocker):
+    from pygitgo.exceptions import GitCommandError
     fake_run = mocker.patch(
         'pygitgo.commands.git_operations.run_command',
-        return_value=subprocess.CalledProcessError(1, 'git')
+        side_effect=GitCommandError(["git", "ls-remote"])
     )
 
     result = confirm_remote_link()
     assert result == False
 
     fake_run.assert_called_once_with(
-        ["git", "ls-remote", "origin"], allow_fail=True, 
+        ["git", "ls-remote", "origin"], 
         loading_msg="Testing connection to remote..."
     )
 
-def test_handle_rebase_no_conflict(mocker):
-    fake_run = mocker.patch(
-        'pygitgo.commands.git_operations.run_command',
-        return_value='ok'
-    )
-
-    result = handle_rebase()
-    assert result == True
-
-    fake_run.assert_called_with(
-        ["git", "status"], allow_fail=True
-    )
-
-def test_handle_rebase_conflict(mocker):
-    fake_run = mocker.patch(
-        'pygitgo.commands.git_operations.run_command',
-        return_value='rebase'
-    )
-
+def test_handle_rebase(mocker):
     from pygitgo.exceptions import GitGoError
-    with pytest.raises(GitGoError):
+    fake_warning = mocker.patch("pygitgo.commands.git_operations.warning")
+    fake_info = mocker.patch("pygitgo.commands.git_operations.info")
+
+    with pytest.raises(GitGoError) as exc_info:
         handle_rebase()
 
-    fake_run.assert_called_with(
-        ["git", "status"], allow_fail=True
-    )
-
-def test_handle_rebase_fallback(mocker):
-    fake_run = mocker.patch(
-        'pygitgo.commands.git_operations.run_command',
-        return_value=subprocess.CalledProcessError(1, 'git')
-    )
-
-    result = handle_rebase()
-    assert result == False
-
-    fake_run.assert_called_with(
-        ["git", "status"], allow_fail=True
-    )
+    assert "Push aborted — rebase conflict in progress." in str(exc_info.value)
+    fake_warning.assert_called_once_with("Conflict detected during rebase.")
+    assert fake_info.call_count == 4
 
 def test_is_branch_exist_true(mocker):
     fake_run = mocker.patch(
@@ -264,9 +243,13 @@ def test_add_remote_origin_switch_origin(mocker):
     )
 
 def test_add_remote_origin_add_origin(mocker):
+    from pygitgo.exceptions import GitCommandError
     fake_run = mocker.patch(
         'pygitgo.commands.git_operations.run_command',
-        return_value=subprocess.CalledProcessError(1, 'git')
+        side_effect=[
+            GitCommandError(["git", "remote", "get-url"]),
+            "added"
+        ]
     )
     fake_success = mocker.patch('pygitgo.commands.git_operations.success')
 
@@ -297,9 +280,13 @@ def test_git_push_already_ssh(mocker):
     )
 
 def test_git_push_no_remote(mocker):
+    from pygitgo.exceptions import GitCommandError
     fake_run = mocker.patch(
         'pygitgo.commands.git_operations.run_command', 
-        return_value=subprocess.CalledProcessError(1, 'git')
+        side_effect=[
+            GitCommandError(["git", "remote", "get-url"]),
+            "pushed"
+        ]
     )
 
     branch = 'main'

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -54,7 +54,6 @@ def test_undo_jump_operation_deletes_ghost_branch(mocker):
     )
     fake_run.assert_any_call(
         ["git", "branch", "-D", "ghost-branch"],
-        allow_fail=True,
         loading_msg="Removing the empty branch 'ghost-branch'..."
     )
     fake_pop.assert_called_once()
@@ -175,7 +174,7 @@ def test_jump_operation_sync_fail_cancel(mocker):
         if cmd == ['git', 'status', '--porcelain']:
             return ''
         if cmd[1] == 'pull':
-            return GitCommandError(cmd, stderr='failed', returncode=1)
+            raise GitCommandError(cmd, stderr='failed', returncode=1)
         return 'ok'
 
     mocker.patch('pygitgo.commands.jump.run_command', side_effect=_run)
@@ -199,7 +198,7 @@ def test_jump_operation_sync_fail_stay(mocker):
         if cmd == ['git', 'status', '--porcelain']:
             return ''
         if cmd[1] == 'pull':
-            return GitCommandError(cmd, stderr='failed', returncode=1)
+            raise GitCommandError(cmd, stderr='failed', returncode=1)
         return 'ok'
 
     mocker.patch('pygitgo.commands.jump.run_command', side_effect=_run)

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,27 +1,108 @@
-from pygitgo.main import link_operation
+import pytest
+from argparse import Namespace
+from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.commands.link import link_operation
 
 
-def test_link_existing_repo_skips_staging(mocker):
-    mocker.patch('pygitgo.main.validate_repo_url', return_value=True)
-    mocker.patch('pygitgo.main.git_init', return_value=False)   
-    fake_commit = mocker.patch('pygitgo.main.git_commit')
-    mocker.patch('pygitgo.main.add_remote_origin')
-    mocker.patch('pygitgo.main.confirm_remote_link', return_value=True)
-    from argparse import Namespace
-    link_operation(Namespace(url="git@github.com:user/repo.git", message="init"))
-    fake_commit.assert_not_called()   
-    
+def test_link_invalid_url():
+    args = Namespace(url="invalid-url", message="Initial commit")
+    with pytest.raises(GitGoError) as exc_info:
+        link_operation(args)
+    assert "Invalid repository URL!" in str(exc_info.value)
 
-def test_link_new_repo_runs_commit(mocker):
-    mocker.patch('pygitgo.main.validate_repo_url', return_value=True)
-    mocker.patch('pygitgo.main.git_init', return_value=True)    
-    fake_commit = mocker.patch('pygitgo.main.git_commit', return_value=True)
-    mocker.patch('pygitgo.main.add_remote_origin')
-    mocker.patch('pygitgo.main.confirm_remote_link', return_value=True)
-    mocker.patch('pygitgo.main.get_current_branch', return_value='main')
-    mocker.patch('pygitgo.main.get_config', return_value='main')
-    mocker.patch('pygitgo.main.run_command', return_value='')
-    mocker.patch('builtins.input', return_value='n')
-    from argparse import Namespace
-    link_operation(Namespace(url="git@github.com:user/repo.git", message="init"))
-    fake_commit.assert_called_once()
+
+def test_link_existing_repo(mocker):
+    mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_init", return_value=False)
+    fake_add_remote = mocker.patch("pygitgo.commands.link.add_remote_origin")
+    fake_confirm = mocker.patch("pygitgo.commands.link.confirm_remote_link", return_value=True)
+    fake_success = mocker.patch("pygitgo.commands.link.success")
+    fake_commit = mocker.patch("pygitgo.commands.link.git_commit")
+
+    args = Namespace(url="git@github.com:user/repo.git", message="Initial commit")
+    link_operation(args)
+
+    fake_add_remote.assert_called_once_with("git@github.com:user/repo.git")
+    fake_confirm.assert_called_once()
+    fake_success.assert_any_call("\nRemote linked to existing repository.")
+    fake_commit.assert_not_called()
+
+
+def test_link_new_repo_no_remote_refs(mocker):
+    mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_init", return_value=True)
+    fake_commit = mocker.patch("pygitgo.commands.link.git_commit", return_value=True)
+    fake_add_remote = mocker.patch("pygitgo.commands.link.add_remote_origin")
+    mocker.patch("pygitgo.commands.link.confirm_remote_link", return_value=True)
+    mocker.patch("pygitgo.commands.link.get_current_branch", return_value="master")
+    mocker.patch("pygitgo.commands.link.get_config", return_value="main")
+    mocker.patch("builtins.input", return_value="y")
+    fake_push = mocker.patch("pygitgo.commands.link.git_push")
+
+    fake_run = mocker.patch("pygitgo.commands.link.run_command", return_value="")  # remote_refs is empty
+
+    args = Namespace(url="git@github.com:user/repo.git", message="Initial commit")
+    link_operation(args)
+
+    fake_commit.assert_called_once_with("Initial commit", loading_msg="Creating initial commit...")
+    fake_add_remote.assert_called_once_with("git@github.com:user/repo.git")
+    fake_run.assert_any_call(["git", "branch", "-m", "main"], loading_msg="Renaming branch 'master' to 'main'...")
+    fake_run.assert_any_call(["git", "ls-remote", "--heads", "origin", "main"], loading_msg="Checking remote branches...")
+    fake_push.assert_called_once_with("main")
+
+
+def test_link_new_repo_with_remote_refs_pull_success(mocker):
+    mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_init", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_commit", return_value=True)
+    mocker.patch("pygitgo.commands.link.add_remote_origin")
+    mocker.patch("pygitgo.commands.link.confirm_remote_link", return_value=True)
+    mocker.patch("pygitgo.commands.link.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.link.get_config", return_value="main")
+    mocker.patch("builtins.input", return_value="n")  # Do not push
+    fake_push = mocker.patch("pygitgo.commands.link.git_push")
+    fake_success = mocker.patch("pygitgo.commands.link.success")
+
+    fake_run = mocker.patch(
+        "pygitgo.commands.link.run_command",
+        side_effect=[
+            "1234567890abcdef refs/heads/main",  # remote_refs check
+            "Successfully pulled"                 # git pull
+        ]
+    )
+
+    args = Namespace(url="git@github.com:user/repo.git", message="Initial commit")
+    link_operation(args)
+
+    fake_run.assert_any_call(
+        ["git", "pull", "origin", "main", "--allow-unrelated-histories", "--no-edit"],
+        loading_msg="Pulling and merging remote content..."
+    )
+    fake_success.assert_any_call("Remote content merged.")
+    fake_push.assert_not_called()
+
+
+def test_link_new_repo_with_remote_refs_pull_failure(mocker):
+    mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_init", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_commit", return_value=True)
+    mocker.patch("pygitgo.commands.link.add_remote_origin")
+    mocker.patch("pygitgo.commands.link.confirm_remote_link", return_value=True)
+    mocker.patch("pygitgo.commands.link.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.link.get_config", return_value="main")
+    fake_error = mocker.patch("pygitgo.commands.link.error")
+    fake_warning = mocker.patch("pygitgo.commands.link.warning")
+
+    fake_run = mocker.patch(
+        "pygitgo.commands.link.run_command",
+        side_effect=[
+            "1234567890abcdef refs/heads/main",  # remote_refs check
+            GitCommandError(["git", "pull"])     # git pull fails
+        ]
+    )
+
+    args = Namespace(url="git@github.com:user/repo.git", message="Initial commit")
+    link_operation(args)
+
+    fake_error.assert_called_once_with("Failed to merge remote content. You may need to resolve conflicts manually.")
+    fake_warning.assert_any_call("Run: git pull origin main --allow-unrelated-histories")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-from pygitgo.main import validate_repo_url
+from pygitgo.commands.link import validate_repo_url
 import pytest
 
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,79 @@
+import pytest
+from pathlib import Path
+from pygitgo.exceptions import GitCommandError
+from pygitgo.auth.manager import login, logout
+
+
+def test_login_already_logged_in(mocker):
+    fake_check = mocker.patch("pygitgo.auth.manager.ssh_utils.check_connection", return_value=True)
+    fake_success = mocker.patch("pygitgo.auth.manager.success")
+
+    result = login()
+
+    assert result is True
+    fake_check.assert_called_once()
+    fake_success.assert_called_once_with("You are already logged in!")
+
+
+def test_login_new_user_success(mocker):
+    # check_connection returns False first, then True on verification
+    fake_check = mocker.patch("pygitgo.auth.manager.ssh_utils.check_connection", side_effect=[False, True])
+    mocker.patch("pygitgo.auth.manager.info")
+    mocker.patch("pygitgo.auth.manager.success")
+    mocker.patch("builtins.input", side_effect=["test@example.com", ""])
+    mocker.patch("pygitgo.auth.manager.ssh_utils.generate_ssh_key", return_value=Path("mock_key"))
+    
+    # Mock reading public key
+    mocker.patch("builtins.open", mocker.mock_open(read_data="ssh-rsa AAAAB3NzaC1yc2E..."))
+    mocker.patch("pygitgo.auth.manager.ssh_utils.open_github_settings")
+    mocker.patch("pygitgo.auth.manager.ssh_utils.get_github_username", return_value="GithubUser")
+    fake_ensure = mocker.patch("pygitgo.auth.account.ensure_user_configure", return_value=True)
+
+    result = login()
+
+    assert result is True
+    fake_ensure.assert_called_once_with(default_email="test@example.com", default_username="GithubUser")
+
+
+def test_login_new_user_verification_fails(mocker):
+    fake_check = mocker.patch("pygitgo.auth.manager.ssh_utils.check_connection", return_value=False)
+    mocker.patch("pygitgo.auth.manager.info")
+    mocker.patch("pygitgo.auth.manager.success")
+    mocker.patch("pygitgo.auth.manager.error")
+    mocker.patch("builtins.input", side_effect=["test@example.com", ""])
+    mocker.patch("pygitgo.auth.manager.ssh_utils.generate_ssh_key", return_value=Path("mock_key"))
+    mocker.patch("builtins.open", mocker.mock_open(read_data="ssh-rsa AAAAB3NzaC1yc2E..."))
+    mocker.patch("pygitgo.auth.manager.ssh_utils.open_github_settings")
+
+    result = login()
+
+    assert result is False
+
+
+def test_logout_not_logged_in(mocker):
+    mocker.patch("pygitgo.auth.manager.ssh_utils.get_ssh_key_path", return_value=Path("non_existent_key"))
+    # mock exists() to return False
+    mocker.patch.object(Path, "exists", return_value=False)
+    fake_warning = mocker.patch("pygitgo.auth.manager.warning")
+
+    result = logout()
+
+    assert result is False
+    fake_warning.assert_called_once_with("You are already logged out (no keys found).")
+
+
+def test_logout_success(mocker):
+    mocker.patch("pygitgo.auth.manager.ssh_utils.get_ssh_key_path", return_value=Path("mock_key"))
+    mocker.patch.object(Path, "exists", return_value=True)
+    fake_remove = mocker.patch("os.remove")
+    fake_path_exists = mocker.patch("os.path.exists", return_value=True)
+    fake_run = mocker.patch("pygitgo.auth.manager.run_command")
+    fake_success = mocker.patch("pygitgo.auth.manager.success")
+
+    result = logout()
+
+    assert result is True
+    assert fake_remove.call_count == 2
+    fake_run.assert_any_call(["git", "config", "--global", "--unset-all", "user.name"])
+    fake_run.assert_any_call(["git", "config", "--global", "--unset-all", "user.email"])
+    fake_success.assert_called_once_with("User successfully logout")

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -18,7 +18,7 @@ def test_pull_operation_success_no_branch(mock_get_branch, mock_success, mock_ru
     pull_operation(args)
     
     assert mock_run_command.call_count == 2
-    mock_run_command.assert_any_call(["git", "ls-remote", "--heads", "origin", "main"], allow_fail=True)
+    mock_run_command.assert_any_call(["git", "ls-remote", "--heads", "origin", "main"])
     mock_run_command.assert_any_call(
         ["git", "pull", "--rebase", "--autostash", "origin", "main"], 
         loading_msg="Downloading latest updates for 'main' (auto-saving your code)..."
@@ -37,7 +37,7 @@ def test_pull_operation_success_with_branch(mock_success, mock_run_command):
     pull_operation(args)
     
     assert mock_run_command.call_count == 2
-    mock_run_command.assert_any_call(["git", "ls-remote", "--heads", "origin", "feature/test"], allow_fail=True)
+    mock_run_command.assert_any_call(["git", "ls-remote", "--heads", "origin", "feature/test"])
     mock_run_command.assert_any_call(
         ["git", "pull", "--rebase", "--autostash", "origin", "feature/test"], 
         loading_msg="Downloading latest updates for 'feature/test' (auto-saving your code)..."
@@ -46,7 +46,7 @@ def test_pull_operation_success_with_branch(mock_success, mock_run_command):
 
 @patch("pygitgo.commands.pull.run_command")
 def test_pull_operation_branch_not_found(mock_run_command):
-    mock_run_command.return_value = subprocess.CalledProcessError(128, ["git", "ls-remote"])
+    mock_run_command.side_effect = GitCommandError(["git", "ls-remote"])
     
     args = Namespace(branch="does-not-exist")
     with pytest.raises(GitGoError):

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,0 +1,147 @@
+import pytest
+from argparse import Namespace
+from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.commands.push import push_operation
+
+
+def test_push_new_branch_flag_no_name():
+    args = Namespace(branch=None, message="Init commit", new=True, select=False)
+    with pytest.raises(GitGoError) as exc_info:
+        push_operation(args)
+    assert "Branch name required when using --new flag!" in str(exc_info.value)
+
+
+def test_push_new_branch_success(mocker):
+    fake_new_branch = mocker.patch("pygitgo.commands.push.git_new_branch")
+    fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
+    fake_push = mocker.patch("pygitgo.commands.push.git_push")
+    mocker.patch("pygitgo.commands.push.print_banner")
+
+    args = Namespace(branch="feature-branch", message="Init commit", new=True, select=False)
+    push_operation(args)
+
+    fake_new_branch.assert_called_once_with("feature-branch")
+    fake_commit.assert_called_once_with("Init commit")
+    fake_push.assert_called_once_with("feature-branch")
+
+
+def test_push_wrong_branch_abort(mocker):
+    mocker.patch("pygitgo.commands.push.is_branch_exist", return_value=True)
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("builtins.input", return_value="n")
+    mocker.patch("pygitgo.commands.push.warning")
+
+    args = Namespace(branch="feature-branch", message="Init commit", new=False, select=False)
+    with pytest.raises(GitGoError) as exc_info:
+        push_operation(args)
+    assert "Push aborted to prevent committing to the wrong branch." in str(exc_info.value)
+
+
+def test_push_wrong_branch_switch(mocker):
+    mocker.patch("pygitgo.commands.push.is_branch_exist", return_value=True)
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("builtins.input", return_value="y")
+    mocker.patch("pygitgo.commands.push.warning")
+    fake_jump = mocker.patch("pygitgo.commands.push.jump_operation")
+    fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
+    fake_push = mocker.patch("pygitgo.commands.push.git_push")
+    mocker.patch("pygitgo.commands.push.print_banner")
+
+    args = Namespace(branch="feature-branch", message="Init commit", new=False, select=False)
+    push_operation(args)
+
+    # Verify that it switches branch first
+    jump_args = fake_jump.call_args[0][0]
+    assert jump_args.branch == "feature-branch"
+    fake_commit.assert_called_once_with("Init commit")
+    fake_push.assert_called_once_with("feature-branch")
+
+
+def test_push_default_branch_and_msg(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.get_config", return_value="Default Msg")
+    mocker.patch("pygitgo.commands.push.info")
+    fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
+    fake_push = mocker.patch("pygitgo.commands.push.git_push")
+    mocker.patch("pygitgo.commands.push.print_banner")
+
+    args = Namespace(branch=None, message=None, new=False, select=False)
+    push_operation(args)
+
+    fake_commit.assert_called_once_with("Default Msg")
+    fake_push.assert_called_once_with("main")
+
+
+def test_push_select_clean(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.get_changed_files", return_value=[])
+    fake_info = mocker.patch("pygitgo.commands.push.info")
+    fake_warning = mocker.patch("pygitgo.commands.push.warning")
+
+    args = Namespace(branch=None, message="Selective push", new=False, select=True)
+    push_operation(args)
+
+    fake_info.assert_called_once_with("\nWorking tree is clean. Nothing to select.")
+    fake_warning.assert_called_once_with("Make some changes first before using GitGo to commit and push.")
+
+
+def test_push_select_no_files_chosen(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.get_changed_files", return_value=["file1.txt", "file2.txt"])
+    mocker.patch("pygitgo.commands.push.display_file_picker", return_value=[])
+    fake_info = mocker.patch("pygitgo.commands.push.info")
+
+    args = Namespace(branch=None, message="Selective push", new=False, select=True)
+    push_operation(args)
+
+    fake_info.assert_called_once_with("\nNo files selected. Push aborted.\n")
+
+
+def test_push_select_success(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.get_changed_files", return_value=["file1.txt", "file2.txt"])
+    mocker.patch("pygitgo.commands.push.display_file_picker", return_value=["file1.txt"])
+    fake_stage = mocker.patch("pygitgo.commands.push.selective_stage")
+    fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
+    fake_push = mocker.patch("pygitgo.commands.push.git_push")
+    mocker.patch("pygitgo.commands.push.print_banner")
+
+    args = Namespace(branch=None, message="Selective push", new=False, select=True)
+    push_operation(args)
+
+    fake_stage.assert_called_once_with(["file1.txt"])
+    fake_commit.assert_called_once_with("Selective push", loading_msg="Commiting selected files...", skip_staging=True)
+    fake_push.assert_called_once_with("main")
+
+
+def test_push_clean_but_unpushed_commits(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.git_commit", return_value=False)  # clean working tree
+    fake_run = mocker.patch("pygitgo.commands.push.run_command", return_value="abc1234 Unpushed commit message\n")
+    fake_warning = mocker.patch("pygitgo.commands.push.warning")
+    fake_push = mocker.patch("pygitgo.commands.push.git_push")
+    mocker.patch("pygitgo.commands.push.print_banner")
+
+    args = Namespace(branch=None, message="Commit message", new=False, select=False)
+    push_operation(args)
+
+    fake_run.assert_called_once_with(["git", "log", "--oneline", "origin/main..HEAD"], loading_msg="Checking for unpushed commits...")
+    fake_warning.assert_called_once_with("\nNo changes to commit, but found unpushed commits. Pushing to remote...")
+    fake_push.assert_called_once_with("main")
+
+
+def test_push_clean_and_up_to_date(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.git_commit", return_value=False)  # clean working tree
+    fake_run = mocker.patch("pygitgo.commands.push.run_command", return_value="")  # no unpushed commits
+    fake_info = mocker.patch("pygitgo.commands.push.info")
+    fake_warning = mocker.patch("pygitgo.commands.push.warning")
+    fake_push = mocker.patch("pygitgo.commands.push.git_push")
+
+    args = Namespace(branch=None, message="Commit message", new=False, select=False)
+    push_operation(args)
+
+    fake_run.assert_called_once_with(["git", "log", "--oneline", "origin/main..HEAD"], loading_msg="Checking for unpushed commits...")
+    fake_info.assert_called_once_with("\nWorking tree is clean and everything is up to date.")
+    fake_warning.assert_called_once_with("Make some changes first before using GitGo to commit and push.")
+    fake_push.assert_not_called()

--- a/tests/test_ssh_utils.py
+++ b/tests/test_ssh_utils.py
@@ -1,0 +1,100 @@
+import pytest
+from pathlib import Path
+from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.auth.ssh_utils import (
+    ensure_github_known_host, check_connection, get_github_username,
+    get_ssh_key_path, generate_ssh_key, open_github_settings,
+    convert_https_to_ssh, is_ssh_url
+)
+
+
+def test_ensure_github_known_host_already_exists(mocker):
+    mocker.patch("pathlib.Path.exists", return_value=True)
+    mocker.patch("builtins.open", mocker.mock_open(read_data="github.com ssh-rsa AAA..."))
+    fake_run = mocker.patch("pygitgo.auth.ssh_utils.run_command")
+
+    ensure_github_known_host()
+
+    fake_run.assert_not_called()
+
+
+def test_ensure_github_known_host_not_exists(mocker):
+    mocker.patch("pathlib.Path.exists", return_value=False)
+    mocker.patch("pathlib.Path.mkdir")
+    mock_file = mocker.patch("builtins.open", mocker.mock_open())
+    
+    # Mock return value of run_command as a completed process
+    mock_process = mocker.MagicMock()
+    mock_process.stdout = "github.com ssh-rsa AAA...\n"
+    fake_run = mocker.patch("pygitgo.auth.ssh_utils.run_command", return_value=mock_process)
+    mocker.patch("pygitgo.auth.ssh_utils.info")
+    mocker.patch("pygitgo.auth.ssh_utils.success")
+
+    ensure_github_known_host()
+
+    fake_run.assert_called_once_with(["ssh-keyscan", "-H", "github.com"], return_complete=True)
+    mock_file().write.assert_any_call("github.com ssh-rsa AAA...\n")
+
+
+def test_check_connection_success(mocker):
+    mocker.patch("pygitgo.auth.ssh_utils.ensure_github_known_host")
+    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Hi user! You've successfully authenticated.")
+
+    result = check_connection()
+    assert result is True
+
+
+def test_check_connection_failure(mocker):
+    mocker.patch("pygitgo.auth.ssh_utils.ensure_github_known_host")
+    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Permission denied.")
+
+    result = check_connection()
+    assert result is False
+
+
+def test_get_github_username_success(mocker):
+    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Hi Alice! You've successfully authenticated.")
+    assert get_github_username() == "Alice"
+
+
+def test_get_github_username_failure(mocker):
+    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Permission denied.")
+    assert get_github_username() is None
+
+
+def test_generate_ssh_key_invalid_email():
+    with pytest.raises(GitGoError) as exc_info:
+        generate_ssh_key("invalid-email")
+    assert "Invalid email address" in str(exc_info.value)
+
+
+def test_generate_ssh_key_success(mocker):
+    mocker.patch("pygitgo.auth.ssh_utils.get_ssh_key_path", return_value=Path("mock_key"))
+    mocker.patch("pathlib.Path.exists", return_value=False)
+    mocker.patch("pathlib.Path.mkdir")
+    fake_run = mocker.patch("pygitgo.auth.ssh_utils.run_command")
+
+    key_path = generate_ssh_key("test@example.com")
+
+    assert key_path == Path("mock_key")
+    fake_run.assert_any_call(
+        command=[
+            "ssh-keygen",
+            "-t", "ed25519",
+            "-C", "test@example.com",
+            "-f", "mock_key",
+            "-N", ""
+        ]
+    )
+    fake_run.assert_any_call(["ssh-add", "mock_key"])
+
+
+def test_convert_https_to_ssh():
+    assert convert_https_to_ssh("https://github.com/user/repo") == "git@github.com:user/repo.git"
+    assert convert_https_to_ssh("https://github.com/user/repo.git") == "git@github.com:user/repo.git"
+    assert convert_https_to_ssh("git@github.com:user/repo.git") is None
+
+
+def test_is_ssh_url():
+    assert is_ssh_url("git@github.com:user/repo.git") is True
+    assert is_ssh_url("https://github.com/user/repo") is False

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -21,7 +21,8 @@ def test_get_changed_files_with_changes(mock_run_command):
 
 @patch("pygitgo.commands.staging.run_command")
 def test_get_changed_files_no_changes(mock_run_command):
-    mock_run_command.return_value = subprocess.CalledProcessError(1, ["git", "status"])
+    from pygitgo.exceptions import GitCommandError
+    mock_run_command.side_effect = GitCommandError(["git", "status"])
 
     files = get_changed_files()
 

--- a/tests/test_stash_operation.py
+++ b/tests/test_stash_operation.py
@@ -1,0 +1,151 @@
+import pytest
+from pygitgo.exceptions import GitCommandError
+from pygitgo.commands.stash_operation import (
+    git_stash_push, git_stash_pop, git_stash_apply,
+    git_stash_drop, git_stash_list, git_stash_clear
+)
+
+
+def test_git_stash_push_success(mocker):
+    fake_run = mocker.patch("pygitgo.commands.stash_operation.run_command", return_value="Saved working directory and index state WIP on main")
+    result = git_stash_push()
+    assert result is True
+    fake_run.assert_called_once_with(
+        ["git", "stash", "push", "-u", "-m", "GitGo Auto-Stash"],
+        loading_msg="Saving your changes..."
+    )
+
+
+def test_git_stash_push_no_changes(mocker):
+    fake_run = mocker.patch("pygitgo.commands.stash_operation.run_command", return_value="No local changes to save")
+    result = git_stash_push()
+    assert result is False
+
+
+def test_git_stash_push_failure(mocker):
+    fake_run = mocker.patch(
+        "pygitgo.commands.stash_operation.run_command",
+        side_effect=GitCommandError(["git", "stash", "push"])
+    )
+    result = git_stash_push()
+    assert result is False
+
+
+def test_git_stash_pop_success(mocker):
+    fake_run = mocker.patch("pygitgo.commands.stash_operation.run_command", return_value="Dropped refs/stash@{0}")
+    result = git_stash_pop()
+    assert result is True
+    fake_run.assert_called_once_with(
+        ["git", "stash", "pop"],
+        loading_msg="Restoring your saved changes..."
+    )
+
+
+def test_git_stash_pop_failure(mocker):
+    fake_run = mocker.patch(
+        "pygitgo.commands.stash_operation.run_command",
+        side_effect=GitCommandError(["git", "stash", "pop"])
+    )
+    result = git_stash_pop()
+    assert result is False
+
+
+def test_git_stash_apply_success_no_id(mocker):
+    fake_run = mocker.patch("pygitgo.commands.stash_operation.run_command", return_value="Applied stash")
+    result = git_stash_apply()
+    assert result is True
+    fake_run.assert_called_once_with(
+        ["git", "stash", "apply"],
+        loading_msg="Applying saved changes..."
+    )
+
+
+def test_git_stash_apply_success_with_id(mocker):
+    fake_run = mocker.patch("pygitgo.commands.stash_operation.run_command", return_value="Applied stash")
+    result = git_stash_apply(stash_id="2")
+    assert result is True
+    fake_run.assert_called_once_with(
+        ["git", "stash", "apply", "stash@{2}"],
+        loading_msg="Applying saved changes..."
+    )
+
+
+def test_git_stash_apply_failure(mocker):
+    fake_run = mocker.patch(
+        "pygitgo.commands.stash_operation.run_command",
+        side_effect=GitCommandError(["git", "stash", "apply"])
+    )
+    result = git_stash_apply()
+    assert result is False
+
+
+def test_git_stash_drop_success_no_id(mocker):
+    fake_run = mocker.patch("pygitgo.commands.stash_operation.run_command", return_value="Dropped stash")
+    result = git_stash_drop()
+    assert result is True
+    fake_run.assert_called_once_with(
+        ["git", "stash", "drop"],
+        loading_msg="Cleaning up stash..."
+    )
+
+
+def test_git_stash_drop_success_with_id(mocker):
+    fake_run = mocker.patch("pygitgo.commands.stash_operation.run_command", return_value="Dropped stash")
+    result = git_stash_drop(stash_id="1")
+    assert result is True
+    fake_run.assert_called_once_with(
+        ["git", "stash", "drop", "stash@{1}"],
+        loading_msg="Cleaning up stash..."
+    )
+
+
+def test_git_stash_drop_failure(mocker):
+    fake_run = mocker.patch(
+        "pygitgo.commands.stash_operation.run_command",
+        side_effect=GitCommandError(["git", "stash", "drop"])
+    )
+    result = git_stash_drop()
+    assert result is False
+
+
+def test_git_stash_list_success(mocker):
+    stash_list_output = "stash@{0}||2026-06-01 10:00:00||Auto-Save\nstash@{1}||2026-06-01 10:05:00||My-State"
+    fake_run = mocker.patch("pygitgo.commands.stash_operation.run_command", return_value=stash_list_output)
+    result = git_stash_list()
+    assert result == stash_list_output
+    fake_run.assert_called_once_with(
+        [
+            "git", "stash", "list",
+            "--date=format:%Y-%m-%d %H:%M:%S",
+            "--pretty=%gd||%cd||%s"
+        ],
+        loading_msg="Fetching stash list..."
+    )
+
+
+def test_git_stash_list_failure(mocker):
+    fake_run = mocker.patch(
+        "pygitgo.commands.stash_operation.run_command",
+        side_effect=GitCommandError(["git", "stash", "list"])
+    )
+    result = git_stash_list()
+    assert result == ""
+
+
+def test_git_stash_clear_success(mocker):
+    fake_run = mocker.patch("pygitgo.commands.stash_operation.run_command", return_value="Cleared all stashes")
+    result = git_stash_clear()
+    assert result is True
+    fake_run.assert_called_once_with(
+        ["git", "stash", "clear"],
+        loading_msg="Clearing all stashes..."
+    )
+
+
+def test_git_stash_clear_failure(mocker):
+    fake_run = mocker.patch(
+        "pygitgo.commands.stash_operation.run_command",
+        side_effect=GitCommandError(["git", "stash", "clear"])
+    )
+    result = git_stash_clear()
+    assert result is False

--- a/tests/test_url_validator.py
+++ b/tests/test_url_validator.py
@@ -1,5 +1,5 @@
 from pygitgo.auth.ssh_utils import is_ssh_url
-from pygitgo.main import validate_repo_url
+from pygitgo.commands.link import validate_repo_url
 import pytest
 
 @pytest.mark.parametrize("url", [


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / internal

## Overview

Removed the `allow_fail` flag from `run_command` in favor of a `try/except` architecture. This fixes the issue of silent bugs happening when we forget to manually check if a command failed. It forces the code to handle the `GitCommandError` explicitly.

Closes #74 

## Changes

- `utils/executor.py`: Removed `allow_fail` from `run_command`. It now always throws a `GitCommandError` on failure.
- Command modules: Replaced manual error checks with standard `try/except GitCommandError` blocks across the app.
- `CHANGELOG.md`: Added notes about the new exception-based architecture.

## How to Test

1. `pip install -e ".[dev]"`
2. `pytest`
3. Expected result: All 198 tests should pass with no errors.

## Checklist

- [x] I tested my changes locally and they work
- [x] I updated `CHANGELOG.md` under the [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md) section
- [ ] I updated `README.md` (if I added or changed a command)
- [x] I added or updated tests for my change (if applicable)
- [x] My change does not break any existing commands (if it does, describe the impact in the Overview)
