### PR TITLE
feat: add simple ctrl+c interrupt handlers for most commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ TODO.md
 docs/
 todo/
 .coverage
+gitgo-simulation/
+simulate_gitgo.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.7.0] - 2026-06-02
+
 ### Added
 - **Auto SSH Commit Signing:** GitGo now uses the SSH key generated during `gitgo user login` to automatically sign all commits using temporary `-c` flags, giving you the Verified badge on GitHub without modifying global git configs.
+- **Safe Interruptions:** Hitting `Ctrl+C` (KeyboardInterrupt) mid-command now triggers smart, command-specific cleanup routines. It aborts in-progress rebases, unstages partial commits, and tells you exactly what state your files are in.
 
 ### Changed
 - Removed the `allow_fail` flag from `run_command` and switched to a robust `try/except` exception-based architecture to prevent silent failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Safe Interruptions:** Hitting `Ctrl+C` (KeyboardInterrupt) mid-command now triggers smart, command-specific cleanup routines. It aborts in-progress rebases, unstages partial commits, and tells you exactly what state your files are in.
 
 ### Changed
+- Removed redundant confirmation prompts during branch switches and deployments, replacing them with automatic actions and post-action undo hints for a smoother UX.
 - Removed the `allow_fail` flag from `run_command` and switched to a robust `try/except` exception-based architecture to prevent silent failures.
 - Refactored CLI messaging to use a consistent tone, removing robotic phrases and filler words.
 - Standardized terminal output spacing and colors across all commands.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ gitgo link https://github.com/username/repo.git "init"
 - **SSH auto-setup & signing:** Generates an `ed25519` key, loads it into `ssh-agent`, opens your GitHub SSH settings page, and automatically signs all future commits for the verified badge.
 - **HTTPS-to-SSH conversion:** Detects HTTPS remotes and rewrites them before pushing if SSH is configured. No manual `git remote set-url`.
 - **Termux support:** Detects the Termux environment, adjusts install paths, uses `termux-open` for browser actions, and patches the dubious ownership Git error.
+- **Safe interruptions:** Hitting `Ctrl+C` midway through a command automatically aborts in-progress merges, cleans up partial states, and tells you exactly what was and wasn't saved.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.7.0b5"
+version = "1.7.0b6"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.7.0b6"
+version = "1.7.0"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/commands/git_branch.py
+++ b/src/pygitgo/commands/git_branch.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.colors import success, error
+from pygitgo.utils.colors import success, error, info
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
 from pygitgo.utils.config import get_config
@@ -36,12 +36,20 @@ def git_new_branch(branch):
         print()
         success(f"Branch '{branch}' created.")
     except GitCommandError:
-        error(f"Failed to create branch '{branch}'! It may already exist.")
-        choice = input("\nWould you like to jump to the existing branch instead? (y/n): ").strip().lower()
-        if choice == "y":
-            from pygitgo.commands.jump import jump_operation
-            jump_operation(Namespace(branch=branch))
+        try:
+            current = get_current_branch()
+        except Exception:
+            current = ""
+
+        if current == branch:
+            info(f"Already on branch '{branch}'. Continuing...")
         else:
-            raise GitGoError(f"Operation canceled. Branch '{branch}' already exists.")
+            error(f"Failed to create branch '{branch}'! It may already exist.")
+            choice = input("\nWould you like to jump to the existing branch instead? (y/n): ").strip().lower()
+            if choice == "y":
+                from pygitgo.commands.jump import jump_operation
+                jump_operation(Namespace(branch=branch))
+            else:
+                raise GitGoError(f"Operation canceled. Branch '{branch}' already exists.")
 
     return branch

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -86,14 +86,13 @@ def jump_operation(args):
                 print()
                 warning("You cannot switch branches with unsaved changes. Jump canceled.")
                 return
-            else:
-                stash_result = git_stash_push(label="GitGo Jump Auto-Stash", loading_msg="Saving your changes before jumping...")
-                if not stash_result:
-                    warning("Stash failed. Your working tree may have untracked files.")
-                    info("Run:  git status   to see what's blocking the stash.")
-                    raise GitGoError("Jump aborted — could not save working changes.")
-                info("Changes saved. Jumping to the new branch...")
-                stashed_code = True
+            stash_result = git_stash_push(label="GitGo Jump Auto-Stash", loading_msg="Saving your changes before jumping...")
+            if not stash_result:
+                warning("Stash failed. Your working tree may have untracked files.")
+                info("Run:  git status   to see what's blocking the stash.")
+                raise GitGoError("Jump aborted: could not save working changes.")
+            info("Changes saved. Jumping to the new branch...")
+            stashed_code = True
 
         if not is_branch_exist(target_branch):
             print()
@@ -119,12 +118,7 @@ def jump_operation(args):
                 run_command(['git', 'pull', 'origin', main_branch], loading_msg=f"Downloading the latest updates from '{main_branch}'...")
             except GitCommandError:
                 warning(f"Failed to pull updates from '{main_branch}'. No internet, or the remote branch doesn't exist yet.")
-                user_input = input("Stay on the new branch without the latest updates? (y/n): ").strip().lower()
-                if user_input != 'y':
-                    undo_jump_operation(original_branch, stashed_code, created_branch)
-                    raise GitGoError("Jump aborted — could not sync with remote.")
-                else:
-                    info(f"On '{target_branch}', but without the latest updates from '{main_branch}'.")
+                info(f"On '{target_branch}', but without the latest updates from '{main_branch}'.")
 
         if stashed_code:
             apply_result = git_stash_apply(loading_msg="Unpacking your unsaved changes...")

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -7,6 +7,7 @@ from pygitgo.commands.stash import (
 from pygitgo.utils.colors import warning, info, success, error
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
+import sys
 
 
 def undo_jump_operation(original_branch, stashed_code, created_branch=None):
@@ -30,10 +31,38 @@ def undo_jump_operation(original_branch, stashed_code, created_branch=None):
     success(f"Back on '{original_branch}'. Your code is safe.")
 
 
+def _jump_interrupt_cleanup(original_branch, stashed_code, created_branch):
+    try:
+        run_command(["git", "rebase", "--abort"])
+        info("In-progress rebase aborted.")
+    except GitCommandError:
+        pass
+
+    try:
+        current_branch = get_current_branch()
+    except Exception:
+        current_branch = original_branch
+
+    if current_branch != original_branch:
+        try:
+            undo_jump_operation(original_branch, stashed_code, created_branch)
+        except GitCommandError:
+            warning(f"Could not auto-revert. You are on '{current_branch}'.")
+            warning(f"Run manually: git checkout {original_branch}")
+            if stashed_code:
+                warning("Then restore your stash: git stash pop")
+    elif stashed_code:
+        pop_result = git_stash_pop()
+        if pop_result:
+            success("Your stashed changes have been restored.")
+        else:
+            warning("Could not restore stash automatically. Run 'gitgo state list' to find it.")
+    else:
+        success("No git state was changed. Your files are safe.")
+
+
 def jump_operation(args):
-
     target_branch = args.branch
-
     original_branch = get_current_branch()
 
     if original_branch == target_branch:
@@ -46,85 +75,91 @@ def jump_operation(args):
         raise GitGoError("Unable to check for uncommitted changes — make sure you're in a valid git repository.")
 
     stashed_code = False
-    if has_changes.strip():
-        print()
-        info("You have unsaved changes here.")
-        user_input = input("Do you want to move these changes to your new branch? (y/n): ").strip().lower()
-        if user_input != 'y':
-            print()
-            warning("You cannot switch branches with unsaved changes. Jump canceled.")
-            return
-        else:
-            stash_result = git_stash_push(label="GitGo Jump Auto-Stash", loading_msg="Saving your changes before jumping...")
-            if not stash_result:
-                warning("Stash failed. Your working tree may have untracked files.")
-                info("Run:  git status   to see what's blocking the stash.")
-                raise GitGoError("Jump aborted — could not save working changes.")
-            info("Changes saved. Jumping to the new branch...")
-            stashed_code = True
-
     created_branch = None
-    if not is_branch_exist(target_branch):
-        print()
-        warning(f"Branch '{target_branch}' does not exist.")
-        user_input = input("Do you want to create it and jump to it? (y/n): ").strip().lower()
 
-        if user_input != 'y':
-            info("Exiting without jumping...")
-            if stashed_code:
-                pop_result = git_stash_pop(loading_msg="Putting your unsaved changes back...")
-                if not pop_result:
-                    warning("Could not restore your unsaved changes automatically. Run 'gitgo state list' to recover them.")
-            return
-
-        git_new_branch(target_branch)
-        created_branch = target_branch
-    else:
-        run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...")
-
-        main_branch = get_main_branch()
-
-        try:
-            run_command(['git', 'pull', 'origin', main_branch], loading_msg=f"Downloading the latest updates from '{main_branch}'...")
-        except GitCommandError:
-            warning(f"Failed to pull updates from '{main_branch}'. No internet, or the remote branch doesn't exist yet.")
-            user_input = input("Stay on the new branch without the latest updates? (y/n): ").strip().lower()
+    try:
+        if has_changes.strip():
+            print()
+            info("You have unsaved changes here.")
+            user_input = input("Do you want to move these changes to your new branch? (y/n): ").strip().lower()
             if user_input != 'y':
-                undo_jump_operation(original_branch, stashed_code, created_branch)
-                raise GitGoError("Jump aborted — could not sync with remote.")
-            else:
-                info(f"On '{target_branch}', but without the latest updates from '{main_branch}'.")
-
-    if stashed_code:
-        apply_result = git_stash_apply(loading_msg="Unpacking your unsaved changes...")
-        if not apply_result:
-            print()
-            error("MERGE CONFLICT — your changes clash with the target branch.")
-            print()
-            info("Option [Y]: Stay here and fix the conflict lines yourself.")
-            info("Option [N]: Cancel everything and go back to where you started.")
-            print()
-            conflict_choice = input("Do you want to fix it yourself? (y/n): ").strip().lower()
-
-            if conflict_choice != 'y':
-                undo_jump_operation(original_branch, stashed_code, created_branch)
+                print()
+                warning("You cannot switch branches with unsaved changes. Jump canceled.")
                 return
             else:
+                stash_result = git_stash_push(label="GitGo Jump Auto-Stash", loading_msg="Saving your changes before jumping...")
+                if not stash_result:
+                    warning("Stash failed. Your working tree may have untracked files.")
+                    info("Run:  git status   to see what's blocking the stash.")
+                    raise GitGoError("Jump aborted — could not save working changes.")
+                info("Changes saved. Jumping to the new branch...")
+                stashed_code = True
+
+        if not is_branch_exist(target_branch):
+            print()
+            warning(f"Branch '{target_branch}' does not exist.")
+            user_input = input("Do you want to create it and jump to it? (y/n): ").strip().lower()
+
+            if user_input != 'y':
+                info("Exiting without jumping...")
+                if stashed_code:
+                    pop_result = git_stash_pop(loading_msg="Putting your unsaved changes back...")
+                    if not pop_result:
+                        warning("Could not restore your unsaved changes automatically. Run 'gitgo state list' to recover them.")
+                return
+
+            git_new_branch(target_branch)
+            created_branch = target_branch
+        else:
+            run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...")
+
+            main_branch = get_main_branch()
+
+            try:
+                run_command(['git', 'pull', 'origin', main_branch], loading_msg=f"Downloading the latest updates from '{main_branch}'...")
+            except GitCommandError:
+                warning(f"Failed to pull updates from '{main_branch}'. No internet, or the remote branch doesn't exist yet.")
+                user_input = input("Stay on the new branch without the latest updates? (y/n): ").strip().lower()
+                if user_input != 'y':
+                    undo_jump_operation(original_branch, stashed_code, created_branch)
+                    raise GitGoError("Jump aborted — could not sync with remote.")
+                else:
+                    info(f"On '{target_branch}', but without the latest updates from '{main_branch}'.")
+
+        if stashed_code:
+            apply_result = git_stash_apply(loading_msg="Unpacking your unsaved changes...")
+            if not apply_result:
                 print()
-                success(f"On '{target_branch}'. Conflict markers are in your files.")
-                warning("Open your editor and fix the conflict lines.")
-                info("Your stash backup is still saved. Run 'gitgo state list' to see it.")
+                error("MERGE CONFLICT — your changes clash with the target branch.")
+                print()
+                info("Option [Y]: Stay here and fix the conflict lines yourself.")
+                info("Option [N]: Cancel everything and go back to where you started.")
+                print()
+                conflict_choice = input("Do you want to fix it yourself? (y/n): ").strip().lower()
+
+                if conflict_choice != 'y':
+                    undo_jump_operation(original_branch, stashed_code, created_branch)
+                    return
+                else:
+                    print()
+                    success(f"On '{target_branch}'. Conflict markers are in your files.")
+                    warning("Open your editor and fix the conflict lines.")
+                    info("Your stash backup is still saved. Run 'gitgo state list' to see it.")
+                    return
+            else:
+                drop_result = git_stash_drop(loading_msg="Cleaning up the temporary stash...")
+                if not drop_result:
+                    warning("Could not clean up the temporary stash. Run 'gitgo state list' to remove it manually.")
+                print()
+                success(f"On '{target_branch}'. Your changes came with you.")
                 return
         else:
-            drop_result = git_stash_drop(loading_msg="Cleaning up the temporary stash...")
-            if not drop_result:
-                warning("Could not clean up the temporary stash. Run 'gitgo state list' to remove it manually.")
             print()
-            success(f"On '{target_branch}'. Your changes came with you.")
+            success(f"On '{target_branch}'.")
             return
-    else:
-        print()
-        success(f"On '{target_branch}'.")
-        return
-    
 
+    except KeyboardInterrupt:
+        print()
+        warning("Jump interrupted (Ctrl+C).")
+        _jump_interrupt_cleanup(original_branch, stashed_code, created_branch)
+        sys.exit(130)

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -1,11 +1,34 @@
+from pygitgo.utils.colors import success, warning, error, highlight, info, print_banner
+from pygitgo.commands.git_remote import add_remote_origin, confirm_remote_link
 from pygitgo.commands.git_core import git_init, git_commit, git_push
 from pygitgo.commands.git_branch import get_current_branch
-from pygitgo.commands.git_remote import add_remote_origin, confirm_remote_link
-from pygitgo.utils.config import get_config
-from pygitgo.utils.executor import run_command
-from pygitgo.utils.colors import success, warning, error, highlight, print_banner
 from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.utils.executor import run_command
+from pygitgo.utils.config import get_config
 from pygitgo.utils.validators import validate_repo_url
+import sys
+
+
+def _link_interrupt_cleanup(repo_url, initialized, committed, remote_added):
+    try:
+        run_command(["git", "merge", "--abort"])
+        info("In-progress merge aborted.")
+    except GitCommandError:
+        pass
+
+    if remote_added:
+        info(f"Remote 'origin' was set to: {repo_url}")
+        info("Run 'gitgo undo link' to remove it, or 'gitgo link <url>' to replace it.")
+
+    if committed:
+        info("Initial commit was created. Your files are safe.")
+        info("Run 'gitgo push' when ready to push to the remote.")
+    elif initialized:
+        info("Git repository was initialized. Your files are safe.")
+        info("Run 'gitgo link <url>' again to complete the setup.")
+    else:
+        success("No git state was changed.")
+
 
 def link_operation(args):
     repo_url = args.url
@@ -18,61 +41,77 @@ def link_operation(args):
         )
 
     commit_message = args.message
-    
+
     highlight("INITIATING LINK OPERATION...")
     highlight(f"Target: {repo_url}")
     print()
-    
-    is_new_repo = git_init()
-    
-    if not is_new_repo:
-        add_remote_origin(repo_url)
 
-        if confirm_remote_link():
-            success("\nRemote linked to existing repository.")
-            success(f"Ready to push with: gitgo push <branch> 'your message'\n")
-        return
+    initialized = False
+    committed = False
+    remote_added = False
 
-    commit_made = git_commit(commit_message, loading_msg="Creating initial commit...")
-    if commit_made:
-        success("Initial commit created.")
-    
-    add_remote_origin(repo_url)
-    
-    if not confirm_remote_link():
-        return
-    
-    current_branch = get_current_branch()
-    main_branch = get_config("default-branch", "main")
-    
-    if current_branch != main_branch:
-        run_command(["git", "branch", "-m", main_branch], loading_msg=f"Renaming branch '{current_branch}' to '{main_branch}'...")
-        current_branch = main_branch
-        
     try:
-        remote_refs = run_command(["git", "ls-remote", "--heads", "origin", main_branch], loading_msg="Checking remote branches...")
-    except GitCommandError:
-        remote_refs = None
+        is_new_repo = git_init()
+        if is_new_repo:
+            initialized = True
 
-    if remote_refs and remote_refs.strip():
-        try:
-            run_command(
-                ["git", "pull", "origin", main_branch, "--allow-unrelated-histories", "--no-edit"],
-                loading_msg="Pulling and merging remote content..."
-            )
-            success("Remote content merged.")
-        except GitCommandError:
-            error("Failed to merge remote content. You may need to resolve conflicts manually.")
-            warning(f"Run: git pull origin {main_branch} --allow-unrelated-histories")
-            warning(f"Then: gitgo push {main_branch} 'your message'\n")
+        if not is_new_repo:
+            add_remote_origin(repo_url)
+            remote_added = True
+
+            if confirm_remote_link():
+                success("\nRemote linked to existing repository.")
+                success(f"Ready to push with: gitgo push <branch> 'your message'\n")
             return
-    
-    print_banner("REPOSITORY INITIALIZED AND LINKED.")
 
-    user_choice = input(f"Do you want to push now? (y/n): ").lower()
-    if user_choice != 'y':
-        return
+        commit_made = git_commit(commit_message, loading_msg="Creating initial commit...")
+        if commit_made:
+            committed = True
+            success("Initial commit created.")
 
-    git_push(current_branch)
+        add_remote_origin(repo_url)
+        remote_added = True
 
-    print_banner("REPOSITORY INITIALIZED AND DEPLOYED.")
+        if not confirm_remote_link():
+            return
+
+        current_branch = get_current_branch()
+        main_branch = get_config("default-branch", "main")
+
+        if current_branch != main_branch:
+            run_command(["git", "branch", "-m", main_branch], loading_msg=f"Renaming branch '{current_branch}' to '{main_branch}'...")
+            current_branch = main_branch
+
+        try:
+            remote_refs = run_command(["git", "ls-remote", "--heads", "origin", main_branch], loading_msg="Checking remote branches...")
+        except GitCommandError:
+            remote_refs = None
+
+        if remote_refs and remote_refs.strip():
+            try:
+                run_command(
+                    ["git", "pull", "origin", main_branch, "--allow-unrelated-histories", "--no-edit"],
+                    loading_msg="Pulling and merging remote content..."
+                )
+                success("Remote content merged.")
+            except GitCommandError:
+                error("Failed to merge remote content. You may need to resolve conflicts manually.")
+                warning(f"Run: git pull origin {main_branch} --allow-unrelated-histories")
+                warning(f"Then: gitgo push {main_branch} 'your message'\n")
+                return
+
+        print_banner("REPOSITORY INITIALIZED AND LINKED.")
+
+        user_choice = input(f"Do you want to push now? (y/n): ").lower()
+        if user_choice != 'y':
+            return
+
+        git_push(current_branch)
+
+        print_banner("REPOSITORY INITIALIZED AND DEPLOYED.")
+
+    except KeyboardInterrupt:
+        print()
+        warning("Link interrupted (Ctrl+C).")
+        _link_interrupt_cleanup(repo_url, initialized, committed, remote_added)
+        sys.exit(130)

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -102,13 +102,12 @@ def link_operation(args):
 
         print_banner("REPOSITORY INITIALIZED AND LINKED.")
 
-        user_choice = input(f"Do you want to push now? (y/n): ").lower()
-        if user_choice != 'y':
-            return
-
         git_push(current_branch)
 
         print_banner("REPOSITORY INITIALIZED AND DEPLOYED.")
+
+        print()
+        info("Run 'gitgo undo commit' to revert this push if the deploy was unintended.")
 
     except KeyboardInterrupt:
         print()

--- a/src/pygitgo/commands/pull.py
+++ b/src/pygitgo/commands/pull.py
@@ -2,6 +2,34 @@ from pygitgo.commands.git_branch import get_current_branch
 from pygitgo.utils.colors import success, warning, error, info
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
+from pathlib import Path
+import sys
+
+
+def _pull_interrupt_cleanup():
+    rebase_in_progress = (
+        Path(".git/rebase-merge").exists() or
+        Path(".git/rebase-apply").exists()
+    )
+
+    if rebase_in_progress:
+        warning("A rebase is in progress from the interrupted pull.")
+        try:
+            run_command(["git", "rebase", "--abort"], loading_msg="Aborting interrupted rebase...")
+            success("Rebase aborted. Branch is back to its pre-pull state.")
+        except GitCommandError:
+            error("Could not abort rebase automatically.")
+            info("Run manually: git rebase --abort")
+    else:
+        success("No partial rebase detected. Branch is clean.")
+
+    try:
+        stash_list = run_command(["git", "stash", "list"])
+        if stash_list and "autostash" in stash_list.lower():
+            info("An autostash entry was found. Your local changes are safe.")
+            info("Run 'gitgo state list' to view it, or 'gitgo state load 1' to restore it.")
+    except GitCommandError:
+        pass
 
 
 def pull_operation(args):
@@ -25,6 +53,12 @@ def pull_operation(args):
         )
 
         success(f"Project is up to date with '{branch}'.")
+
+    except KeyboardInterrupt:
+        print()
+        warning("Pull interrupted (Ctrl+C).")
+        _pull_interrupt_cleanup()
+        sys.exit(130)
 
     except GitCommandError as e:
         error_msg = str(e).lower()

--- a/src/pygitgo/commands/push.py
+++ b/src/pygitgo/commands/push.py
@@ -70,6 +70,7 @@ def push_operation(args):
         original_head = None
 
     created_branch = None
+    auto_switched_from = None
 
     try:
         if args.new:
@@ -86,11 +87,9 @@ def push_operation(args):
             elif branch and is_branch_exist(branch):
                 current_branch = get_current_branch()
                 if current_branch != branch:
-                    warning(f"You are currently on branch '{current_branch}', not '{branch}'.")
-                    user_choice = input(f"Do you want to switch to branch '{branch}'? (y/n): ").lower()
-                    if user_choice != 'y':
-                        raise GitGoError("\nPush aborted to prevent committing to the wrong branch.\n")
+                    info(f"Switching to target branch '{branch}'...")
                     jump_operation(Namespace(branch=branch))
+                    auto_switched_from = current_branch
 
             elif not branch:
                 branch = get_current_branch()
@@ -141,6 +140,11 @@ def push_operation(args):
                     return
 
         print_banner("MISSION COMPLETE. ALL TARGETS COMMITTED AND PUSHED.")
+
+        if auto_switched_from:
+            print()
+            info(f"Switched from '{auto_switched_from}' to '{branch}' automatically.")
+            info(f"Run 'gitgo undo commit' then 'gitgo jump {auto_switched_from}' to revert this push and return.")
 
     except KeyboardInterrupt:
         print()

--- a/src/pygitgo/commands/push.py
+++ b/src/pygitgo/commands/push.py
@@ -1,12 +1,61 @@
-from pygitgo.commands.git_core import git_commit, git_push
-from pygitgo.commands.git_branch import git_new_branch, get_current_branch, is_branch_exist
 from pygitgo.commands.staging import get_changed_files, display_file_picker, selective_stage
-from pygitgo.commands.jump import jump_operation
-from pygitgo.utils.config import get_config
-from pygitgo.utils.executor import run_command
-from pygitgo.utils.colors import info, warning, error, print_banner
+from pygitgo.commands.git_branch import git_new_branch, get_current_branch, is_branch_exist
+from pygitgo.utils.colors import info, warning, error, success, print_banner
+from pygitgo.commands.git_core import git_commit, git_push
 from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.commands.jump import jump_operation
+from pygitgo.utils.executor import run_command
+from pygitgo.utils.config import get_config
 from argparse import Namespace
+import sys
+
+
+def _push_interrupt_cleanup(original_branch, original_head, created_branch):
+    try:
+        current_branch = get_current_branch()
+    except Exception:
+        current_branch = original_branch
+
+    try:
+        current_head = run_command(["git", "rev-parse", "HEAD"]).strip()
+    except GitCommandError:
+        current_head = original_head
+
+    commit_was_made = bool(original_head and current_head and current_head != original_head)
+
+    if commit_was_made:
+        info(f"Commit was saved locally on '{current_branch}' but was not pushed.")
+        info("Run 'gitgo push' to retry the push.")
+        info("Run 'gitgo undo commit' to undo the commit instead.")
+        return
+
+    try:
+        status = run_command(["git", "status", "--porcelain"])
+        has_staged = any(
+            ln and ln[0] not in (' ', '?', '!')
+            for ln in status.splitlines()
+        )
+    except GitCommandError:
+        has_staged = False
+
+    if has_staged:
+        try:
+            run_command(["git", "reset", "HEAD"])
+            success("Staged files have been unstaged. Your edits are safe.")
+        except GitCommandError:
+            warning("Could not unstage automatically. Run 'git reset HEAD' manually.")
+    else:
+        success("No git state was changed. Your files are safe.")
+
+    if created_branch and not commit_was_made:
+        try:
+            if current_branch == created_branch:
+                run_command(["git", "checkout", original_branch])
+            run_command(["git", "branch", "-D", created_branch])
+            success(f"Empty branch '{created_branch}' removed. Back on '{original_branch}'.")
+        except GitCommandError:
+            warning(f"Could not auto-remove '{created_branch}'.")
+            warning(f"Run: git checkout {original_branch} && git branch -D {created_branch}")
 
 
 def push_operation(args):
@@ -14,70 +63,87 @@ def push_operation(args):
     message = args.message
     select = args.select if hasattr(args, 'select') else False
 
-    if args.new:
-        if not branch:
-            raise GitGoError("\nBranch name required when using --new flag!\n")
-        git_new_branch(branch)
-    else:
-        if branch and not message and not is_branch_exist(branch):
-            message = branch
-            branch = get_current_branch()
-            info(f"No branch name provided. Using current branch: '{branch}'\n")
-            
-        elif branch and is_branch_exist(branch):
-            current_branch = get_current_branch()
-            if current_branch != branch:
-                warning(f"You are currently on branch '{current_branch}', not '{branch}'.")
-                user_choice = input(f"Do you want to switch to branch '{branch}'? (y/n): ").lower()
-                if user_choice != 'y':
-                    raise GitGoError("\nPush aborted to prevent committing to the wrong branch.\n")
-                jump_operation(Namespace(branch=branch))
-    
-        elif not branch:
-            branch = get_current_branch()
+    original_branch = get_current_branch()
+    try:
+        original_head = run_command(["git", "rev-parse", "HEAD"]).strip()
+    except GitCommandError:
+        original_head = None
 
-    if not message:
-        message = get_config("default-message", "New Project Update")
-        info(f"No commit message provided. Using default: '{message}'\n")
+    created_branch = None
 
-    if select:
-        files = get_changed_files()
-        if not files:
-            info("\nWorking tree is clean. Nothing to select.")
-            warning("Make some changes first before using GitGo to commit and push.")
-            return
-
-        selected = display_file_picker(files)
-        if not selected:
-            info("\nNo files selected. Push aborted.\n")
-            return
-
-        selective_stage(selected)
-        commit_made = git_commit(message, loading_msg="Commiting selected files...", skip_staging=True)
-        
-        if commit_made:
-            git_push(branch)
-        
-    else:
-        commit_made = git_commit(message)
-        
-        if commit_made:
-            git_push(branch)
+    try:
+        if args.new:
+            if not branch:
+                raise GitGoError("\nBranch name required when using --new flag!\n")
+            git_new_branch(branch)
+            created_branch = branch
         else:
-            try:
-                unpushed = run_command(["git", "log", "--oneline", f"origin/{branch}..HEAD"], loading_msg="Checking for unpushed commits...")
+            if branch and not message and not is_branch_exist(branch):
+                message = branch
+                branch = get_current_branch()
+                info(f"No branch name provided. Using current branch: '{branch}'\n")
 
-                if unpushed.strip():
-                    warning("\nNo changes to commit, but found unpushed commits. Pushing to remote...")
-                    git_push(branch)
-                else:
-                    info("\nWorking tree is clean and everything is up to date.")
-                    warning("Make some changes first before using GitGo to commit and push.")
-                    return
-                
-            except (GitCommandError, Exception):
-                warning("\nNo changes to commit. Cannot verify remote status.")
-                warning("Make some changes first or check your git remote configuration.")
+            elif branch and is_branch_exist(branch):
+                current_branch = get_current_branch()
+                if current_branch != branch:
+                    warning(f"You are currently on branch '{current_branch}', not '{branch}'.")
+                    user_choice = input(f"Do you want to switch to branch '{branch}'? (y/n): ").lower()
+                    if user_choice != 'y':
+                        raise GitGoError("\nPush aborted to prevent committing to the wrong branch.\n")
+                    jump_operation(Namespace(branch=branch))
+
+            elif not branch:
+                branch = get_current_branch()
+
+        if not message:
+            message = get_config("default-message", "New Project Update")
+            info(f"No commit message provided. Using default: '{message}'\n")
+
+        if select:
+            files = get_changed_files()
+            if not files:
+                info("\nWorking tree is clean. Nothing to select.")
+                warning("Make some changes first before using GitGo to commit and push.")
                 return
 
-    print_banner("MISSION COMPLETE. ALL TARGETS COMMITTED AND PUSHED.")
+            selected = display_file_picker(files)
+            if not selected:
+                info("\nNo files selected. Push aborted.\n")
+                return
+
+            selective_stage(selected)
+            commit_made = git_commit(message, loading_msg="Commiting selected files...", skip_staging=True)
+
+            if commit_made:
+                git_push(branch)
+
+        else:
+            commit_made = git_commit(message)
+
+            if commit_made:
+                git_push(branch)
+            else:
+                try:
+                    unpushed = run_command(
+                        ["git", "log", "--oneline", f"origin/{branch}..HEAD"],
+                        loading_msg="Checking for unpushed commits..."
+                    )
+                    if unpushed.strip():
+                        warning("\nNo changes to commit, but found unpushed commits. Pushing to remote...")
+                        git_push(branch)
+                    else:
+                        info("\nWorking tree is clean and everything is up to date.")
+                        warning("Make some changes first before using GitGo to commit and push.")
+                        return
+                except (GitCommandError, Exception):
+                    warning("\nNo changes to commit. Cannot verify remote status.")
+                    warning("Make some changes first or check your git remote configuration.")
+                    return
+
+        print_banner("MISSION COMPLETE. ALL TARGETS COMMITTED AND PUSHED.")
+
+    except KeyboardInterrupt:
+        print()
+        warning("Push interrupted (Ctrl+C).")
+        _push_interrupt_cleanup(original_branch, original_head, created_branch)
+        sys.exit(130)

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -5,6 +5,7 @@ from pygitgo.commands.stash import (
 )
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
+import sys
 
 
 
@@ -123,11 +124,23 @@ def load_state(state_id=None):
 
     selected_state = save_states[int(state_id) - 1]
 
-    apply_result = git_stash_apply(stash_id=str(selected_state["stash_index"]))
-    if not apply_result:
-        error(f"Failed to load state. There may be a conflict with your current changes.")
-        raise GitGoError("Load failed — resolve conflicts first.")
-    success(f"State '{selected_state['message']}' restored.")
+    try:
+        apply_result = git_stash_apply(stash_id=str(selected_state["stash_index"]))
+        if not apply_result:
+            error(f"Failed to load state. There may be a conflict with your current changes.")
+            raise GitGoError("Load failed — resolve conflicts first.")
+        success(f"State '{selected_state['message']}' restored.")
+
+    except KeyboardInterrupt:
+        print()
+        warning("State load interrupted (Ctrl+C).")
+        try:
+            run_command(["git", "checkout", "--", "."])
+            success("Partial changes cleaned up. Your stash is still saved.")
+            info(f"Run 'gitgo state load {state_id}' to try again.")
+        except GitCommandError:
+            warning("Could not clean up automatically. Run 'git status' to check, then 'git checkout -- .' if needed.")
+        sys.exit(130)
 
 
 def save_state(state_name=None):
@@ -139,7 +152,7 @@ def save_state(state_name=None):
     except GitCommandError:
         warning("Could not check for local changes - make sure you're in a valid git repository.")
         return
-    
+
     if not has_changes.strip():
         info("No local changes to save.")
         return

--- a/src/pygitgo/commands/undo.py
+++ b/src/pygitgo/commands/undo.py
@@ -1,6 +1,7 @@
-from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.colors import success, warning, info, error
+from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
+import sys
 
 
 def undo_commit():
@@ -26,10 +27,25 @@ def undo_changes():
         info("Canceled. Your files are safe.")
         return
 
-    run_command(["git", "reset", "--hard", "HEAD"], loading_msg="Throwing away edits...")
-    run_command(["git", "clean", "-fd"], loading_msg="Removing new files...")
+    reset_done = False
+    try:
+        run_command(["git", "reset", "--hard", "HEAD"], loading_msg="Throwing away edits...")
+        reset_done = True
+        run_command(["git", "clean", "-fd"], loading_msg="Removing new files...")
+        success("Working tree reset. All changes discarded.")
 
-    success("Working tree reset. All changes discarded.")
+    except KeyboardInterrupt:
+        print()
+        if reset_done:
+            warning("Interrupted during file removal. Finishing cleanup...")
+            try:
+                run_command(["git", "clean", "-fd"])
+                success("Working tree reset. All changes discarded.")
+            except GitCommandError:
+                warning("Could not finish cleanup. Run 'git clean -fd' manually.")
+        else:
+            success("Reset canceled before any changes were made. Your files are safe.")
+        sys.exit(130)
 
 
 def undo_operation(args):

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -1,8 +1,7 @@
 from pygitgo.utils.update_checker import check_for_updates_background
+from pygitgo.utils.bootstrap import ensure_first_run_setup
 from pygitgo.utils.colors import info, warning, error
 from pygitgo.commands.config import config_operation
-from pygitgo.exceptions import GitGoError
-from pygitgo.utils.bootstrap import ensure_first_run_setup
 from pygitgo.commands.state import state_operation
 from pygitgo.commands.undo import undo_operation
 from pygitgo.commands.pull import pull_operation
@@ -10,6 +9,7 @@ from pygitgo.commands.jump import jump_operation
 from pygitgo.commands.link import link_operation
 from pygitgo.commands.push import push_operation
 from pygitgo.commands.user import user_operation
+from pygitgo.exceptions import GitGoError
 import argparse
 import sys
 
@@ -182,6 +182,10 @@ def main():
     except GitGoError as e:
         error(f"{e}")
         sys.exit(1)
+    except KeyboardInterrupt:
+        print()
+        warning("Operation canceled.")
+        sys.exit(130)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_git_branch.py
+++ b/tests/test_git_branch.py
@@ -20,32 +20,51 @@ def test_git_branch_logic(mocker):
 def test_git_branch_exists_jump_yes(mocker):
     from pygitgo.exceptions import GitCommandError
     fake_run = mocker.patch("pygitgo.commands.git_branch.run_command", side_effect=GitCommandError(["git", "checkout", "-b"]))
+    mocker.patch("pygitgo.commands.git_branch.get_current_branch", return_value="main")  # different branch
     mocker.patch("builtins.input", return_value="y")
     fake_jump = mocker.patch("pygitgo.commands.jump.jump_operation")
     fake_error = mocker.patch("pygitgo.commands.git_branch.error")
 
     branch_name = "existing-branch"
     result = git_new_branch(branch_name)
-    
+
     assert result == "existing-branch"
     fake_error.assert_called_once_with(f"Failed to create branch '{branch_name}'! It may already exist.")
-    
+
     args = fake_jump.call_args[0][0]
     assert args.branch == branch_name
+
 
 def test_git_branch_exists_jump_no(mocker):
     from pygitgo.exceptions import GitCommandError, GitGoError
     fake_run = mocker.patch("pygitgo.commands.git_branch.run_command", side_effect=GitCommandError(["git", "checkout", "-b"]))
+    mocker.patch("pygitgo.commands.git_branch.get_current_branch", return_value="main")  # different branch
     mocker.patch("builtins.input", return_value="n")
     fake_jump = mocker.patch("pygitgo.commands.jump.jump_operation")
     fake_error = mocker.patch("pygitgo.commands.git_branch.error")
 
     branch_name = "existing-branch"
-    
+
     with pytest.raises(GitGoError):
         git_new_branch(branch_name)
     fake_error.assert_called_once_with(f"Failed to create branch '{branch_name}'! It may already exist.")
     fake_jump.assert_not_called()
+
+
+def test_git_branch_already_on_target_skips_prompt(mocker):
+    from pygitgo.exceptions import GitCommandError
+    mocker.patch("pygitgo.commands.git_branch.run_command", side_effect=GitCommandError(["git", "checkout", "-b"]))
+    mocker.patch("pygitgo.commands.git_branch.get_current_branch", return_value="feat/safe-interruptions")
+    fake_info = mocker.patch("pygitgo.commands.git_branch.info", create=True)
+    fake_input = mocker.patch("builtins.input")
+    fake_jump = mocker.patch("pygitgo.commands.jump.jump_operation")
+
+    result = git_new_branch("feat/safe-interruptions")
+
+    assert result == "feat/safe-interruptions"
+    fake_input.assert_not_called()  # no prompt shown
+    fake_jump.assert_not_called()   # no jump triggered
+    fake_info.assert_called_once_with("Already on branch 'feat/safe-interruptions'. Continuing...")
 
 def test_get_current_branch(mocker):
     fake_run = mocker.patch("pygitgo.commands.git_branch.run_command", return_value='main')

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -88,6 +88,23 @@ def test_jump_operation_has_changes_exit(mocker):
     fake_warning.assert_any_call("You cannot switch branches with unsaved changes. Jump canceled.")
 
 
+def test_jump_operation_has_changes_moves_to_branch(mocker):
+    mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
+    mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
+    mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
+    mocker.patch('builtins.input', return_value='y')
+    fake_info = mocker.patch('pygitgo.commands.jump.info')
+    fake_success = mocker.patch('pygitgo.commands.jump.success')
+    mocker.patch('pygitgo.commands.jump.git_stash_push', return_value=True)
+    mocker.patch('pygitgo.commands.jump.git_stash_apply', return_value=True)
+    mocker.patch('pygitgo.commands.jump.git_stash_drop', return_value=True)
+    mocker.patch('pygitgo.commands.jump.run_command', side_effect=lambda *a, **kw: 'M file.txt' if a[0] == ['git', 'status', '--porcelain'] else 'ok')
+
+    assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
+    fake_info.assert_any_call("Changes saved. Jumping to the new branch...")
+    fake_success.assert_called_with("On 'feature'. Your changes came with you.")
+
+
 def test_jump_operation_no_changes(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
@@ -98,6 +115,7 @@ def test_jump_operation_no_changes(mocker):
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
 
     fake_success.assert_called_with("On 'feature'.")
+
 
 
 def test_jump_operation_save_changes_error(mocker):
@@ -115,11 +133,11 @@ def test_jump_operation_save_changes_error(mocker):
     fake_warning.assert_called_with("Stash failed. Your working tree may have untracked files.")
 
 
-
 def test_jump_operation_branch_not_exist_cancel_operation(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=False)
+    # First input: "move changes?" yes, Second: "create branch?" no
     mocker.patch('builtins.input', side_effect=['y', 'n'])
 
     fake_info = mocker.patch('pygitgo.commands.jump.info')
@@ -129,7 +147,7 @@ def test_jump_operation_branch_not_exist_cancel_operation(mocker):
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
 
-    fake_info.assert_any_call('Changes saved. Jumping to the new branch...')
+    fake_info.assert_any_call("Changes saved. Jumping to the new branch...")
     fake_info.assert_any_call("Exiting without jumping...")
     fake_pop.assert_called_once()
 
@@ -139,6 +157,7 @@ def test_jump_operation_branch_not_exist_create_branch(mocker):
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=False)
     mocker.patch('pygitgo.commands.jump.git_new_branch', return_value=None)
+    # First input: "move changes?" yes, Second: "create branch?" yes
     mocker.patch('builtins.input', side_effect=['y', 'y'])
 
     fake_success = mocker.patch('pygitgo.commands.jump.success')
@@ -154,42 +173,16 @@ def test_jump_operation_branch_not_exist_create_branch(mocker):
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
 
-    fake_info.assert_called_with('Changes saved. Jumping to the new branch...')
+    fake_info.assert_any_call("Changes saved. Jumping to the new branch...")
     fake_success.assert_any_call("On 'feature'. Your changes came with you.")
     fake_apply.assert_called_once()
     fake_drop.assert_called_once()
-
-
-def test_jump_operation_sync_fail_cancel(mocker):
-    mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
-    mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
-    mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
-    mocker.patch('pygitgo.commands.jump.undo_jump_operation', return_value=None)
-    mocker.patch('builtins.input', side_effect=['n'])   # "stay?" → no
-
-    fake_warning = mocker.patch('pygitgo.commands.jump.warning')
-
-    def _run(*args, **kwargs):
-        cmd = args[0]
-        if cmd == ['git', 'status', '--porcelain']:
-            return ''
-        if cmd[1] == 'pull':
-            raise GitCommandError(cmd, stderr='failed', returncode=1)
-        return 'ok'
-
-    mocker.patch('pygitgo.commands.jump.run_command', side_effect=_run)
-
-    assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 1
-    fake_warning.assert_any_call(
-        "Failed to pull updates from 'main'. No internet, or the remote branch doesn't exist yet."
-    )
 
 
 def test_jump_operation_sync_fail_stay(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
-    mocker.patch('builtins.input', side_effect=['y'])   # "stay?" → yes
 
     fake_info = mocker.patch('pygitgo.commands.jump.info')
 
@@ -209,12 +202,12 @@ def test_jump_operation_sync_fail_stay(mocker):
     )
 
 
-
 def test_jump_operation_merge_conflict_cancel(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
     mocker.patch('pygitgo.commands.jump.undo_jump_operation', return_value=None)
+    # First: "move changes?" yes, Second: "fix conflict?" no
     mocker.patch('builtins.input', side_effect=['y', 'n'])
 
     fake_error = mocker.patch('pygitgo.commands.jump.error')
@@ -237,6 +230,7 @@ def test_jump_operation_merge_conflict_stay(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
+    # First: "move changes?" yes, Second: "fix conflict?" yes
     mocker.patch('builtins.input', side_effect=['y', 'y'])
 
     fake_success = mocker.patch('pygitgo.commands.jump.success')
@@ -260,3 +254,4 @@ def test_jump_operation_merge_conflict_stay(mocker):
     fake_warning.assert_any_call("Open your editor and fix the conflict lines.")
     fake_info.assert_any_call("Your stash backup is still saved. Run 'gitgo state list' to see it.")
     fake_drop.assert_not_called()
+

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -36,7 +36,6 @@ def test_link_new_repo_no_remote_refs(mocker):
     mocker.patch("pygitgo.commands.link.confirm_remote_link", return_value=True)
     mocker.patch("pygitgo.commands.link.get_current_branch", return_value="master")
     mocker.patch("pygitgo.commands.link.get_config", return_value="main")
-    mocker.patch("builtins.input", return_value="y")
     fake_push = mocker.patch("pygitgo.commands.link.git_push")
 
     fake_run = mocker.patch("pygitgo.commands.link.run_command", return_value="")  # remote_refs is empty
@@ -59,7 +58,6 @@ def test_link_new_repo_with_remote_refs_pull_success(mocker):
     mocker.patch("pygitgo.commands.link.confirm_remote_link", return_value=True)
     mocker.patch("pygitgo.commands.link.get_current_branch", return_value="main")
     mocker.patch("pygitgo.commands.link.get_config", return_value="main")
-    mocker.patch("builtins.input", return_value="n")  # Do not push
     fake_push = mocker.patch("pygitgo.commands.link.git_push")
     fake_success = mocker.patch("pygitgo.commands.link.success")
 
@@ -79,7 +77,7 @@ def test_link_new_repo_with_remote_refs_pull_success(mocker):
         loading_msg="Pulling and merging remote content..."
     )
     fake_success.assert_any_call("Remote content merged.")
-    fake_push.assert_not_called()
+    fake_push.assert_called_once_with("main")
 
 
 def test_link_new_repo_with_remote_refs_pull_failure(mocker):

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -1,9 +1,9 @@
-import pytest
 from unittest.mock import patch, MagicMock
 from pygitgo.commands.pull import pull_operation
 from pygitgo.exceptions import GitCommandError, GitGoError
 from argparse import Namespace
 import subprocess
+import pytest
 
 @patch("pygitgo.commands.pull.run_command")
 @patch("pygitgo.commands.pull.success")
@@ -67,3 +67,63 @@ def test_pull_operation_merge_conflict(mock_run_command):
     args = Namespace(branch="main")
     with pytest.raises(GitGoError):
         pull_operation(args)
+
+
+@patch("pygitgo.commands.pull.run_command")
+@patch("pygitgo.commands.pull.success")
+@patch("pygitgo.commands.pull.warning")
+@patch("pygitgo.commands.pull.Path")
+def test_pull_keyboard_interrupt_rebase_in_progress(mock_path, mock_warning, mock_success, mock_run_command):
+    def side_effect_fn(*args, **kwargs):
+        cmd = args[0]
+        if cmd[1] == "ls-remote":
+            return "1234567890abcdef"
+        if cmd[1] == "pull":
+            raise KeyboardInterrupt()
+        return ""
+
+    mock_run_command.side_effect = side_effect_fn
+
+    mock_path_instance = MagicMock()
+    mock_path_instance.exists.return_value = True
+    mock_path.return_value = mock_path_instance
+
+    args = Namespace(branch="main")
+    with pytest.raises(SystemExit) as sys_exit:
+        pull_operation(args)
+
+    assert sys_exit.value.code == 130
+    mock_run_command.assert_any_call(["git", "rebase", "--abort"], loading_msg="Aborting interrupted rebase...")
+    mock_warning.assert_any_call("Pull interrupted (Ctrl+C).")
+    mock_warning.assert_any_call("A rebase is in progress from the interrupted pull.")
+    mock_success.assert_called_with("Rebase aborted. Branch is back to its pre-pull state.")
+
+
+@patch("pygitgo.commands.pull.run_command")
+@patch("pygitgo.commands.pull.success")
+@patch("pygitgo.commands.pull.warning")
+@patch("pygitgo.commands.pull.Path")
+def test_pull_keyboard_interrupt_no_rebase(mock_path, mock_warning, mock_success, mock_run_command):
+    def side_effect_fn(*args, **kwargs):
+        cmd = args[0]
+        if cmd[1] == "ls-remote":
+            return "1234567890abcdef"
+        if cmd[1] == "pull":
+            raise KeyboardInterrupt()
+        return ""
+
+    mock_run_command.side_effect = side_effect_fn
+
+    mock_path_instance = MagicMock()
+    mock_path_instance.exists.return_value = False
+    mock_path.return_value = mock_path_instance
+
+    args = Namespace(branch="main")
+    with pytest.raises(SystemExit) as sys_exit:
+        pull_operation(args)
+
+    assert sys_exit.value.code == 130
+    for call in mock_run_command.call_args_list:
+        assert "--abort" not in call[0][0]
+    mock_success.assert_called_with("No partial rebase detected. Branch is clean.")
+

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -25,23 +25,10 @@ def test_push_new_branch_success(mocker):
     fake_push.assert_called_once_with("feature-branch")
 
 
-def test_push_wrong_branch_abort(mocker):
+def test_push_wrong_branch_auto_switch(mocker):
     mocker.patch("pygitgo.commands.push.is_branch_exist", return_value=True)
     mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
-    mocker.patch("builtins.input", return_value="n")
-    mocker.patch("pygitgo.commands.push.warning")
-
-    args = Namespace(branch="feature-branch", message="Init commit", new=False, select=False)
-    with pytest.raises(GitGoError) as exc_info:
-        push_operation(args)
-    assert "Push aborted to prevent committing to the wrong branch." in str(exc_info.value)
-
-
-def test_push_wrong_branch_switch(mocker):
-    mocker.patch("pygitgo.commands.push.is_branch_exist", return_value=True)
-    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
-    mocker.patch("builtins.input", return_value="y")
-    mocker.patch("pygitgo.commands.push.warning")
+    fake_info = mocker.patch("pygitgo.commands.push.info")
     fake_jump = mocker.patch("pygitgo.commands.push.jump_operation")
     fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
     fake_push = mocker.patch("pygitgo.commands.push.git_push")
@@ -50,6 +37,9 @@ def test_push_wrong_branch_switch(mocker):
     args = Namespace(branch="feature-branch", message="Init commit", new=False, select=False)
     push_operation(args)
 
+    fake_info.assert_any_call("Switching to target branch 'feature-branch'...")
+    fake_info.assert_any_call("Switched from 'main' to 'feature-branch' automatically.")
+    fake_info.assert_any_call("Run 'gitgo undo commit' then 'gitgo jump main' to revert this push and return.")
     jump_args = fake_jump.call_args[0][0]
     assert jump_args.branch == "feature-branch"
     fake_commit.assert_called_once_with("Init commit")

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,7 +1,7 @@
-import pytest
-from argparse import Namespace
-from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.commands.push import push_operation
+from pygitgo.exceptions import GitGoError
+from argparse import Namespace
+import pytest
 
 
 def test_push_new_branch_flag_no_name():
@@ -50,7 +50,6 @@ def test_push_wrong_branch_switch(mocker):
     args = Namespace(branch="feature-branch", message="Init commit", new=False, select=False)
     push_operation(args)
 
-    # Verify that it switches branch first
     jump_args = fake_jump.call_args[0][0]
     assert jump_args.branch == "feature-branch"
     fake_commit.assert_called_once_with("Init commit")
@@ -116,7 +115,7 @@ def test_push_select_success(mocker):
 
 def test_push_clean_but_unpushed_commits(mocker):
     mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
-    mocker.patch("pygitgo.commands.push.git_commit", return_value=False)  # clean working tree
+    mocker.patch("pygitgo.commands.push.git_commit", return_value=False) 
     fake_run = mocker.patch("pygitgo.commands.push.run_command", return_value="abc1234 Unpushed commit message\n")
     fake_warning = mocker.patch("pygitgo.commands.push.warning")
     fake_push = mocker.patch("pygitgo.commands.push.git_push")
@@ -125,15 +124,15 @@ def test_push_clean_but_unpushed_commits(mocker):
     args = Namespace(branch=None, message="Commit message", new=False, select=False)
     push_operation(args)
 
-    fake_run.assert_called_once_with(["git", "log", "--oneline", "origin/main..HEAD"], loading_msg="Checking for unpushed commits...")
+    fake_run.assert_any_call(["git", "log", "--oneline", "origin/main..HEAD"], loading_msg="Checking for unpushed commits...")
     fake_warning.assert_called_once_with("\nNo changes to commit, but found unpushed commits. Pushing to remote...")
     fake_push.assert_called_once_with("main")
 
 
 def test_push_clean_and_up_to_date(mocker):
     mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
-    mocker.patch("pygitgo.commands.push.git_commit", return_value=False)  # clean working tree
-    fake_run = mocker.patch("pygitgo.commands.push.run_command", return_value="")  # no unpushed commits
+    mocker.patch("pygitgo.commands.push.git_commit", return_value=False) 
+    fake_run = mocker.patch("pygitgo.commands.push.run_command", return_value="") 
     fake_info = mocker.patch("pygitgo.commands.push.info")
     fake_warning = mocker.patch("pygitgo.commands.push.warning")
     fake_push = mocker.patch("pygitgo.commands.push.git_push")
@@ -141,7 +140,47 @@ def test_push_clean_and_up_to_date(mocker):
     args = Namespace(branch=None, message="Commit message", new=False, select=False)
     push_operation(args)
 
-    fake_run.assert_called_once_with(["git", "log", "--oneline", "origin/main..HEAD"], loading_msg="Checking for unpushed commits...")
+    fake_run.assert_any_call(["git", "log", "--oneline", "origin/main..HEAD"], loading_msg="Checking for unpushed commits...")
     fake_info.assert_called_once_with("\nWorking tree is clean and everything is up to date.")
     fake_warning.assert_called_once_with("Make some changes first before using GitGo to commit and push.")
     fake_push.assert_not_called()
+
+
+def test_push_keyboard_interrupt_no_changes_made(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.git_commit", side_effect=KeyboardInterrupt)
+    fake_run = mocker.patch("pygitgo.commands.push.run_command")
+    fake_run.return_value = "initial_hash" 
+    fake_warning = mocker.patch("pygitgo.commands.push.warning")
+    fake_info = mocker.patch("pygitgo.commands.push.info")
+
+    fake_run.side_effect = lambda cmd, *a, **kw: "" if cmd == ["git", "status", "--porcelain"] else "initial_hash"
+
+    args = Namespace(branch=None, message="Commit message", new=False, select=False)
+    with pytest.raises(SystemExit) as sys_exit:
+        push_operation(args)
+
+    assert sys_exit.value.code == 130
+    fake_warning.assert_any_call("Push interrupted (Ctrl+C).")
+
+
+def test_push_keyboard_interrupt_commit_made(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
+    mocker.patch("pygitgo.commands.push.git_push", side_effect=KeyboardInterrupt)
+    
+    fake_run = mocker.patch("pygitgo.commands.push.run_command")
+    fake_run.side_effect = ["old_hash", "new_hash"] # first call: initial rev-parse HEAD. second call: post-cleanup check.
+    
+    fake_warning = mocker.patch("pygitgo.commands.push.warning")
+    fake_info = mocker.patch("pygitgo.commands.push.info")
+
+    args = Namespace(branch=None, message="Commit message", new=False, select=False)
+    with pytest.raises(SystemExit) as sys_exit:
+        push_operation(args)
+
+    assert sys_exit.value.code == 130
+    fake_warning.assert_any_call("Push interrupted (Ctrl+C).")
+    fake_info.assert_any_call("Commit was saved locally on 'main' but was not pushed.")
+
+

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -205,3 +205,22 @@ def test_delete_state_no_args(mocker):
 
     fake_drop.assert_called_once_with(stash_id="0")
     fake_success.assert_called_once_with("State 2 deleted.")
+
+
+def test_load_state_keyboard_interrupt(mocker):
+    save_states = [{"id": 1, "ref": "stash@{0}", "date": "date", "message": "msg", "stash_index": 0}]
+    mocker.patch("pygitgo.commands.state.all_save_state", return_value=save_states)
+    mocker.patch("pygitgo.commands.state.git_stash_apply", side_effect=KeyboardInterrupt)
+    fake_run = mocker.patch("pygitgo.commands.state.run_command")
+    fake_warning = mocker.patch("pygitgo.commands.state.warning")
+    fake_success = mocker.patch("pygitgo.commands.state.success")
+
+    from pygitgo.commands.state import load_state
+    with pytest.raises(SystemExit) as sys_exit:
+        load_state("1")
+
+    assert sys_exit.value.code == 130
+    fake_warning.assert_any_call("State load interrupted (Ctrl+C).")
+    fake_run.assert_called_once_with(["git", "checkout", "--", "."])
+    fake_success.assert_called_once_with("Partial changes cleaned up. Your stash is still saved.")
+


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Refactor / internal

## Overview

Added a simple `Ctrl+C` handling across the CLI and streamlined command prompts. Instead of crashing and leaving Git in a dirty state, interrupting a command now triggers a cleanup routine that aborts active rebases, unstages files, and tells the user exactly where things stopped. I also removed redundant prompts during common actions (like switching branches or pushing) and replaced them with automatic actions and post-action hints for a much faster UX.

## Changes

- `push`: unstages files if interrupted before commit. if committed but not pushed, tells you how to undo it or retry. removes the new branch if `--new` was used but nothing committed. auto-switches to target branches without asking, and prints a hint on how to undo it.
- `pull`: checks `.git/rebase-merge` and `.git/rebase-apply` and automatically runs `git rebase --abort` if caught mid-rebase.
- `jump`: aborts any active rebase and runs `undo_jump_operation` to safely return to the original branch. auto-stashes changes when jumping branches instead of blocking you.
- `link`: aborts in-progress merges from `--allow-unrelated-histories` and tracks exactly which init/commit/remote steps finished. auto-pushes when done and tells you how to undo it.
- `state`: if interrupted mid-apply, runs `git checkout -- .` to clean up the partial application so the stash can be retried cleanly.
- `main.py`: added a generic fallback catch for all other simple commands to exit cleanly with code 130.
- `tests`: added 5 new `KeyboardInterrupt` mock tests to guarantee cleanup logic runs correctly and exits with 130. updated prompt tests to check for auto-actions and undo hints.

## How to Test

1. Run `gitgo pull` and hit `Ctrl+C` right as it starts downloading.
2. Run `gitgo push` and hit `Ctrl+C` during the staging phase.
3. Run `gitgo jump <new-branch>` with uncommitted files and watch it auto-stash and move them.
4. Run `pytest` to verify all 204 tests pass.
5. Expected result: Git operations abort cleanly, the repo state stays clean, and the terminal prints a clear "Operation interrupted" message. Automated flows proceed without interrupting.

## Checklist

- [x] I tested my changes locally and they work
- [x] I updated `CHANGELOG.md` under the `[Unreleased]` section
- [x] I updated `README.md` (if I added or changed a command)
- [x] I added or updated tests for my change (if applicable)
- [x] My change does not break any existing commands