### PR TITLE
docs: add a sponsor badge and remove kofi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-ko_fi: huerte
+github: Huerte

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI Downloads](https://img.shields.io/pypi/dm/pygitgo?color=blue)](https://pypi.org/project/pygitgo)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Ko-fi](https://img.shields.io/badge/Support-Ko--fi-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/huerte)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/Huerte?label=Sponsor&logo=github&color=EA4AAA)](https://github.com/sponsors/Huerte)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS%20%7C%20Termux-lightgrey)](https://github.com/Huerte/GitGo)
 
 **Stop typing the same five Git commands. Run one instead.**
@@ -16,10 +16,10 @@
 
 <br />
 
-If GitGo saves you time, consider buying me a coffee. It helps keep the project going.
+If GitGo saves you time, consider sponsoring. It helps keep the project going.
 
-<a href="https://ko-fi.com/huerte">
-  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Support on Ko-fi" />
+<a href="https://github.com/sponsors/Huerte">
+  <img src="https://img.shields.io/badge/Sponsor%20on%20GitHub-%E2%9D%A4-EA4AAA?style=for-the-badge&logo=github" alt="Sponsor on GitHub" />
 </a>
 
 </div>

--- a/src/pygitgo/commands/init.py
+++ b/src/pygitgo/commands/init.py
@@ -1,0 +1,161 @@
+import urllib
+
+from pygitgo.commands.git_core import git_init
+from pygitgo.exceptions import GitGoError
+from pygitgo.utils.colors import *
+import os
+
+LANG_ALIASES: dict[str, str] = {
+    "py":        "python",
+    "rs":        "rust",
+    "rb":        "ruby",
+    "kt":        "kotlin",
+    "cpp":       "c++",
+    "cc":        "c++",
+    "cplusplus": "c++",
+    "cs":        "csharp",
+
+    "js":         "node",
+    "ts":         "node",
+    "javascript": "node",
+    "typescript": "node",
+    "golang":     "go",
+    "dotnet":     "csharp",
+    ".net":       "csharp",
+}
+
+PYTHON_REQUIREMENTS = """# Add project dependencies here
+"""
+
+NODE_PACKAGE_JSON = """{{
+  "name": "{name}",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {{
+    "start": "node index.js"
+  }}
+}}
+"""
+
+RUST_CARGO_TOML = """[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+"""
+
+DART_PUBSPEC_YAML = """name: {name}
+description: A new Dart project.
+version: 1.0.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+"""
+
+FLUTTER_PUBSPEC_YAML = """name: {name}
+description: A new Flutter project.
+version: 1.0.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+"""
+
+GO_MOD = """module {name}
+
+go 1.20
+"""
+
+README_TEMPLATE = """# {name}
+
+Scaffolded u
+"""
+
+
+def _fetch_available_templates():
+    pass
+
+def _fetch_gitignore(language):
+    url = (
+        f"https://raw.githubusercontent.com/github/gitignore/main/{language}.gitignore"
+    )
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "GitGo-CLI"}
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=15) as response:
+            return response.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            raise GitGoError(
+                f"Language '{language}' not found in GitHub gitignore templates."
+            )
+        raise GitGoError(f"Failed to fetch gitignore: HTTP {e.code}")
+    except Exception as e:
+        raise GitGoError(f"Network error fetching gitignore: {e}")
+
+
+def _download_and_extract_template():
+    pass
+
+
+def _scaffold_language():
+    pass
+
+
+def _resolved_language(language, available):
+    normalized = LANG_ALIASES.get(language.lower(), language.lower())
+    if normalized in available:
+        return available[normalized]
+
+    suggestions = sorted(
+        (
+            t for t in available
+            if len(normalized) >= 2 and normalized[:2] == t[:2]
+        ),
+        key=lambda t: abs(len(t) - len(normalized)),
+    )[:5]
+    hint = f"\n  Similar templates: {', '.join(suggestions)}" if suggestions else ""
+    raise GitGoError(f"No .gitignore template found for '{language}'.{hint}")
+
+def _download_and_extract_template(template)
+
+
+def init_operation(args):
+    
+    target_dir = args.name
+
+    if os.path.exists(target_dir) and os.listdir(target_dir):
+        raise GitGoError(f"Folder '{target_dir}' already exists and is not empty.")
+    
+    os.makedirs(target_dir, exist_ok=True)
+
+    orig_cwd = os.getcwd()
+
+    try:
+        if args.template:
+            _download_and_extract_template(args.template, target_dir)
+        elif args.lang:
+            _scaffold_language(args.lang, target_dir, target_dir)
+
+        os.chdir(target_dir)
+        git_init()
+
+        success(f"\nInitialized empty Git repository in {os.path.abspath('.')}")
+        info("Next step: Create a remote repo with 'gitgo new <name>'")
+
+    except Exception as e:
+        if os.path.exists(target_dir) and not os.listdir(target_dir):
+            try:
+                os.rmdir(target_dir)
+            except Exception:
+                pass
+        raise e
+    finally:
+        os.chdir(orig_cwd)
+
+


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / internal

## Overview

Github approved the sponsors profile so im moving everything over from ko-fi. This updates the repo to point directly to the native github sponsors page.

## Changes

- `README.md`: swapped out the ko-fi badge and support button for github sponsors links
- `.github/FUNDING.yml`: replaced the ko_fi entry with the github entry so the native sponsor button shows up on the repo

## Checklist

- [x] I tested my changes locally and they work
- [ ] I updated `CHANGELOG.md` under the `[Unreleased]` section
- [ ] I updated `README.md` (if I added or changed a command)
- [ ] I added or updated tests for my change (if applicable)
- [x] My change does not break any existing commands
