### PR TITLE
fix: cache github token and handle expiry for gitgo new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - **Documentation:** Added `docs/login-guide.md`, a step-by-step login guide with screenshots covering the full `gitgo user login` flow for starters.
 - **Internal Utils:** Centralized browser opening logic and updated the auth manager to support repo creation tokens.
+- `gitgo new` token prompt now opens the classic PAT page by default, making it easier to create non-expiring tokens.
+
+### Fixed
+- Fixed `gitgo new` opening the browser on every call. It now saves the token to git config (`gitgo.github-token`) after the first paste.
+- Fixed `gitgo new` crashing when an old token expires. It now clears the dead token and re-prompts automatically.
 
 ---
  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.7.1"
+version = "1.8.1"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/commands/new.py
+++ b/src/pygitgo/commands/new.py
@@ -1,5 +1,6 @@
-from pygitgo.utils.colors import info, success
+from pygitgo.utils.colors import info, success, warning
 from pygitgo.utils.platform import open_url
+from pygitgo.utils.config import get_config, set_config
 from pygitgo.exceptions import GitGoError
 import subprocess
 import urllib
@@ -8,12 +9,42 @@ import os
 
 GITHUB_API = "https://api.github.com"
 
+_TOKEN_URL = "https://github.com/settings/tokens/new?scopes=repo&description=GitGo"
+
+
+def _clear_saved_token():
+    try:
+        subprocess.run(
+            ["git", "config", "--global", "--unset", "gitgo.github-token"],
+            capture_output=True
+        )
+    except Exception:
+        pass
+
+
+def _prompt_for_token():
+    info("GitGo needs a GitHub token to create repositories.")
+    info("Required scope: repo")
+    info("Tip: set 'Expiration' to 'No expiration' for a permanent token (Classic PAT only).")
+    open_url(_TOKEN_URL)
+
+    token = input(
+        "After creating the token on GitHub,\n"
+        "come back here and paste it: "
+    ).strip()
+
+    if not token:
+        raise GitGoError("Cancelled. No repository was created.")
+
+    set_config("github-token", token, silent=True)
+    return token
+
+
 def _get_github_token():
-    
     token = os.environ.get("GITHUB_TOKEN", "").strip()
     if token:
         return token
-    
+
     try:
         result = subprocess.run(
             ["gh", "auth", "token"],
@@ -25,20 +56,12 @@ def _get_github_token():
                 return token
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
-    
-    info("GitGo needs a GitHub token to create repositories.")
-    info("Required scope: repo")
-    open_url("https://github.com/settings/tokens/new?scopes=repo")
 
-    token = input(
-        "After creating the token on GitHub,\n"
-        "come back here and paste it: "
-    ).strip()
+    token = get_config("github-token", "").strip()
+    if token:
+        return token
 
-    if not token:
-        raise GitGoError("Cancelled. No repository was created.")
-
-    return token
+    return _prompt_for_token()
 
 
 def create_github_repo(name, private=False, description="", token=None):
@@ -71,7 +94,11 @@ def create_github_repo(name, private=False, description="", token=None):
         if e.code == 422:
             raise GitGoError(f"Repository '{name}' already exists on GitHub.")
         elif e.code == 401:
-            raise GitGoError("Unauthorized. Your token might be expired. Try logging in again.")
+            warning("Token is invalid or expired. Clearing saved token...")
+            _clear_saved_token()
+            warning("Please create a new token. Opening GitHub now...")
+            new_token = _prompt_for_token()
+            return create_github_repo(name, private=private, description=description, token=new_token)
 
         body = e.read().decode("utf-8", errors="replace")
         try:

--- a/src/pygitgo/utils/config.py
+++ b/src/pygitgo/utils/config.py
@@ -15,16 +15,18 @@ def get_config(key, fallback_value):
         return fallback_value
 
 
-def set_config(key, value):
+def set_config(key, value, silent=False):
 
     config_key = f"gitgo.{key}"
 
     try:
-        result = run_command(['git', 'config', '--global', config_key, value])
-        success(f"\nConfiguration saved: {key} = '{value}'")
+        run_command(['git', 'config', '--global', config_key, value])
+        if not silent:
+            success(f"\nConfiguration saved: {key} = '{value}'")
         return True
     except GitCommandError:
-        error(f"\nFailed to save configuration for '{key}'.")
+        if not silent:
+            error(f"\nFailed to save configuration for '{key}'.")
         return False
 
 

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -1,11 +1,11 @@
-import pytest
 from unittest.mock import patch, MagicMock
+from pygitgo.exceptions import GitGoError
 from pygitgo.commands.new import (
     _get_github_token,
     create_github_repo,
     new_operation,
 )
-from pygitgo.exceptions import GitGoError
+import pytest
 
 
 @patch.dict("os.environ", {"GITHUB_TOKEN": "test-token"})
@@ -27,7 +27,7 @@ def test_get_github_token_gh_cli(mock_run):
 def test_get_github_token_guided(mock_input, mock_open_url, mock_run):
     mock_run.side_effect = FileNotFoundError()
     assert _get_github_token() == "user-pasted-token"
-    mock_open_url.assert_called_once_with("https://github.com/settings/tokens/new?scopes=repo")
+    mock_open_url.assert_called_once_with("https://github.com/settings/tokens/new?scopes=repo&description=GitGo")
 
 
 @patch.dict("os.environ", {}, clear=True)


### PR DESCRIPTION
<!-- If you are unsure how to fill this out, see CONTRIBUTING.md: https://github.com/Huerte/GitGo/blob/main/CONTRIBUTING.md -->
<!-- Note: These hidden comments guide you while typing. GitHub hides them automatically when you submit. -->

## Type

<!-- Check the one that fits. Put an 'x' inside the brackets: [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal

## Overview

<!-- Describe what you changed and why. 2-3 sentences is enough. -->

the new command was opening the browser to ask for a token every single time. this fixes that by saving the token locally after the first time you paste it. it also catches expired tokens so you dont get stuck with a failing command.

## Changes

<!-- One bullet per change. Say what changed and what effect it has. -->

- `gitgo new`: saves the token to `gitgo.github-token` in your git config so it reuses it next time
- `gitgo new`: catches 401 errors from github, deletes the dead token, and automatically asks for a new one
- `gitgo new`: opens the classic token page by default so you can select the no expiration option
- `utils/config.py`: adds a silent flag to `set_config` so the raw token doesnt leak into the terminal output

## How to Test

<!-- Write the exact steps a reviewer should run to verify your change works.
     Be specific — include the exact commands and what output to expect.
     If this PR only updates documentation, you can remove this section.
-->

1. `pip install -e ".[dev]"`
2. run `gitgo new test-repo1` and paste your token when it asks
3. run `gitgo new test-repo2`
4. Expected result: the second run creates the repo immediately without opening the browser or asking for the token again

## Checklist

<!-- Put an 'x' inside the brackets to check a box: [x] -->

- [x] I tested my changes locally and they work
- [x] I updated `CHANGELOG.md` under the [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md) section
- [ ] I updated `README.md` (if I added or changed a command)
- [x] I added or updated tests for my change (if applicable)
- [x] My change does not break any existing commands (if it does, describe the impact in the Overview)
