### PR TITLE
fix: prevent double git init in quickstart command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Template URLs:** `gitgo init --template` now supports full GitHub URLs (e.g., `https://github.com/owner/repo` or `.git` extensions) in addition to the short `owner/repo` format.
 
 ### Fixed
+- Fixed `gitgo new` skipping the initial commit and push due to a double `git init` bug. It now properly deploys the scaffolded files.
 - Fixed `gitgo new` opening the browser on every call. It now saves the token to git config (`gitgo.github-token`) after the first paste.
 - Fixed `gitgo new` crashing when an old token expires. It now clears the dead token and re-prompts automatically.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.8.1"
+version = "1.8.0"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -30,7 +30,7 @@ def _link_interrupt_cleanup(repo_url, initialized, committed, remote_added):
         success("No git state was changed.")
 
 
-def link_core(repo_url, commit_message="Initial commit", silent=False):
+def link_core(repo_url, commit_message="Initial commit", silent=False, already_initialized=False):
     if not validate_repo_url(repo_url):
         raise GitGoError(
             "\nInvalid repository URL!\n"
@@ -43,9 +43,13 @@ def link_core(repo_url, commit_message="Initial commit", silent=False):
     remote_added = False
 
     try:
-        is_new_repo = git_init()
-        if is_new_repo:
+        if already_initialized:
+            is_new_repo = True
             initialized = True
+        else:
+            is_new_repo = git_init()
+            if is_new_repo:
+                initialized = True
 
         if not is_new_repo:
             add_remote_origin(repo_url)

--- a/src/pygitgo/commands/new.py
+++ b/src/pygitgo/commands/new.py
@@ -12,7 +12,7 @@ def new_operation(args):
 
     repo_url = repo_operation(args, silent=True)
 
-    link_core(repo_url, "Initial commit", silent=True)
+    link_core(repo_url, "Initial commit", silent=True, already_initialized=True)
 
     print_banner("PROJECT LAUNCHED. SCAFFOLDED, CREATED, AND DEPLOYED.")
 

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -21,7 +21,7 @@ def test_new_operation_quickstart(mock_chdir, mock_link_core, mock_repo_operatio
     mock_init_operation.assert_called_once_with(args)
     mock_chdir.assert_called_once_with("my-project")
     mock_repo_operation.assert_called_once_with(args, silent=True)
-    mock_link_core.assert_called_once_with("https://github.com/user/my-project.git", "Initial commit", silent=True)
+    mock_link_core.assert_called_once_with("https://github.com/user/my-project.git", "Initial commit", silent=True, already_initialized=True)
 
     captured = capsys.readouterr()
     assert "undo link" in captured.out


### PR DESCRIPTION
<!-- If you are unsure how to fill this out, see CONTRIBUTING.md: https://github.com/Huerte/GitGo/blob/main/CONTRIBUTING.md -->
<!-- Note: These hidden comments guide you while typing. GitHub hides them automatically when you submit. -->

## Type

<!-- Check the one that fits. Put an 'x' inside the brackets: [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal

## Overview

<!-- Describe what you changed and why. 2-3 sentences is enough. -->

fixed a bug where `gitgo new` was quietly skipping the initial commit and push step. `init_operation` was calling `git init`, and then `link_core` was running it again. `link_core` saw it was already a repo and wrongly assumed it was just connecting an existing project to a remote, so it skipped pushing the newly scaffolded files.

Closes # <!-- Remove the line if this PR does not address an open Issue -->

## Changes

<!-- One bullet per change. Say what changed and what effect it has. -->

- `link.py`: added an `already_initialized` parameter to `link_core`. when true, it skips calling `git init` and proceeds directly to creating the initial commit and pushing.
- `new.py`: updated `new_operation` to pass `already_initialized=True` when it calls `link_core`.
- `test_new.py`: updated the test assertions to expect the new parameter.
- `CHANGELOG.md`: added an entry documenting the bug fix under the unreleased section.

## How to Test

<!-- Write the exact steps a reviewer should run to verify your change works.
     Be specific — include the exact commands and what output to expect.
     If this PR only updates documentation, you can remove this section.
-->

1. `pip install -e ".[dev]"`
2. `gitgo new test-app python -p`
3. Expected result: it should now properly commit and push the scaffolded files to github instead of stopping at "Remote linked to existing repository".
4. `pytest tests/test_new.py -v`
5. Expected result: tests should pass successfully.

## Checklist

<!-- Put an 'x' inside the brackets to check a box: [x] -->

- [x] I tested my changes locally and they work
- [x] I updated `CHANGELOG.md` under the [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md) section
- [ ] I updated `README.md` (if I added or changed a command)
- [x] I added or updated tests for my change (if applicable)
- [x] My change does not break any existing commands (if it does, describe the impact in the Overview)
