### PR TITLE
Fix/login flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,47 +3,32 @@
 
 ## Type
 
-<!-- Check the one that fits. Put an 'x' inside the brackets: [x] -->
+<!-- Put an 'x' inside the brackets: [x] -->
 
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Documentation
 - [ ] Refactor / internal
 
-## Overview
-
-<!-- Describe what you changed and why. 2-3 sentences is enough. -->
-
-Closes # <!-- Remove the line if this PR does not address an open Issue -->
-
 ## Changes
 
 <!-- One bullet per change. Say what changed and what effect it has.
      Examples:
-     - `gitgo push`: no longer stops mid-run after a branch jump. It now completes the commit and push automatically.
+     - `gitgo push`: no longer stops mid-run after a branch jump.
      - `CONTRIBUTING.md`: removed the `pytest-cov` task from the Good First Issues table.
      - CI: added a workflow to automatically run tests on Windows and Ubuntu.
 -->
 
 -
 
-## How to Test
-
-<!-- Write the exact steps a reviewer should run to verify your change works.
-     Be specific — include the exact commands and what output to expect.
-     If this PR only updates documentation, you can remove this section.
--->
-
-1. `pip install -e ".[dev]"`
-2.
-3. Expected result:
+Closes # <!-- Remove if this PR does not address an open issue -->
 
 ## Checklist
 
-<!-- Put an 'x' inside the brackets to check a box: [x] -->
+<!-- Put an 'x' inside the brackets: [x] -->
 
-- [ ] I tested my changes locally and they work
-- [ ] I updated `CHANGELOG.md` under the [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md) section
-- [ ] I updated `README.md` (if I added or changed a command)
-- [ ] I added or updated tests for my change (if applicable)
-- [ ] My change does not break any existing commands (if it does, describe the impact in the Overview)
+- [ ] Tested locally and changes work as expected
+- [ ] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md)
+- [ ] `README.md` updated (if a command was added or changed)
+- [ ] Tests added or updated (if applicable)
+- [ ] No existing commands are broken (if they are, describe the impact above)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Performance:** Cached the SSH handshake response so it doesn't run twice during login.
 - **UX:** Added a loading spinner to the GitHub connection check so the terminal doesn't freeze silently.
 - **Performance:** Removed a redundant network check that ran the first time you used any command.
+- **UX Refactoring:** Merged success messages with loading spinners across all commands to produce cleaner, single-line console output and avoid trailing blank/duplicated lines.
+- **Tests Update:** Adjusted unit tests and mocks for the new ok_text parameters to ensure complete coverage, successfully passing all 250 test cases.
+- **Tests Update:** Conditionally applied yaspin colors based on TTY presence to eliminate UserWarnings during pytest and in CI environments.
 - **Documentation:** Added `docs/login-guide.md`, a step-by-step login guide with screenshots covering the full `gitgo user login` flow for starters.
 - **Internal Utils:** Centralized browser opening logic and updated the auth manager to support repo creation tokens.
 - `gitgo new` token prompt now opens the classic PAT page by default, making it easier to create non-expiring tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,18 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Quickstart Command:** Added `gitgo new <name> [lang]` as a one-shot command that scaffolds a local project, creates the GitHub repo, and pushes it all in sequence.
 
 ### Changed
+- **Performance:** Cached the SSH handshake response so it doesn't run twice during login.
+- **UX:** Added a loading spinner to the GitHub connection check so the terminal doesn't freeze silently.
+- **Performance:** Removed a redundant network check that ran the first time you used any command.
 - **Documentation:** Added `docs/login-guide.md`, a step-by-step login guide with screenshots covering the full `gitgo user login` flow for starters.
 - **Internal Utils:** Centralized browser opening logic and updated the auth manager to support repo creation tokens.
 - `gitgo new` token prompt now opens the classic PAT page by default, making it easier to create non-expiring tokens.
 - **Python Scaffolding:** `gitgo init <name> python` now generates a modern `pyproject.toml` and `.python-version` file instead of `requirements.txt`.
 - **Template URLs:** `gitgo init --template` now supports full GitHub URLs (e.g., `https://github.com/owner/repo` or `.git` extensions) in addition to the short `owner/repo` format.
+- Cleaned up old commented-out code in `manager.py`.
 
 ### Fixed
+- Fixed the 4-10 second silent delay during `gitgo user login`.
 - Fixed `gitgo new` skipping the initial commit and push due to a double `git init` bug. It now properly deploys the scaffolded files.
 - Fixed `gitgo new` opening the browser on every call. It now saves the token to git config (`gitgo.github-token`) after the first paste.
 - Fixed `gitgo new` crashing when an old token expires. It now clears the dead token and re-prompts automatically.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Performance:** Cached the SSH handshake response so it doesn't run twice during login.
 - **UX:** Added a loading spinner to the GitHub connection check so the terminal doesn't freeze silently.
 - **Performance:** Removed a redundant network check that ran the first time you used any command.
-- **UX Refactoring:** Merged success messages with loading spinners across all commands to produce cleaner, single-line console output and avoid trailing blank/duplicated lines.
-- **Tests Update:** Adjusted unit tests and mocks for the new ok_text parameters to ensure complete coverage, successfully passing all 250 test cases.
-- **Tests Update:** Conditionally applied yaspin colors based on TTY presence to eliminate UserWarnings during pytest and in CI environments.
-- **Documentation:** Added `docs/login-guide.md`, a step-by-step login guide with screenshots covering the full `gitgo user login` flow for starters.
+- **UX Refactoring:** Merged success and error messages with loading spinners across all commands. Success text now prints inline via `ok_text`, and failure text via `err_text`/`fail_text`, eliminating trailing blank lines and duplicate output.
+- **Tests:** Updated all unit test mocks for the new `ok_text`, `err_text`, and `fail_text` parameters. Conditionally applied yaspin colors based on TTY presence to eliminate UserWarnings in pytest and CI. 250 tests passing, 0 warnings.
+- **Documentation:** Added `docs/login-guide.md`, a step-by-step login guide covering the full `gitgo user login` flow.
 - **Internal Utils:** Centralized browser opening logic and updated the auth manager to support repo creation tokens.
 - `gitgo new` token prompt now opens the classic PAT page by default, making it easier to create non-expiring tokens.
 - **Python Scaffolding:** `gitgo init <name> python` now generates a modern `pyproject.toml` and `.python-version` file instead of `requirements.txt`.

--- a/docs/login-guide.md
+++ b/docs/login-guide.md
@@ -39,11 +39,11 @@ Open your terminal and run:
 gitgo user login
 ```
 
-If you are already connected to GitHub, GitGo will tell you right away and stop. You don't need to do anything else.
+If you are already connected to GitHub, GitGo checks if the connection uses a GitGo-managed key:
 
-![Already logged in message](../assets/guides/login/step-1-already-logged-in.png)
+- **Managed key found**: GitGo configures SSH signing, ensures your Git identity is set up, and confirms you are already logged in via GitGo.
+- **Unmanaged key found**: GitGo warns you that the active connection is not using a GitGo-managed key. To set up SSH signing and verified commits through GitGo, you must first log out by running `gitgo user logout`, then run `gitgo user login` again.
 
-> *If you see this, you're already connected. Jump to [Troubleshooting](#troubleshooting) if something feels wrong.*
 
 ---
 
@@ -147,13 +147,20 @@ Go to [github.com/settings/keys](https://github.com/settings/keys) and check. Yo
 The key must start with `ssh-ed25519` and end with your email. If you accidentally included the `===` lines or missed part of the key, delete the entry on GitHub and add it again with the correct text.
 
 **Is the SSH agent running?**
-The key needs to be loaded into `ssh-agent` to work. Run this in your terminal:
+The key needs to be loaded into `ssh-agent` to work. GitGo tries to automatically start the SSH agent. If this fails, start it manually based on your operating system:
 
-```bash
-eval $(ssh-agent) && ssh-add
-```
+- **Windows**: Open PowerShell as Administrator and run:
+  ```powershell
+  Set-Service ssh-agent -StartupType Automatic
+  Start-Service ssh-agent
+  ```
+  Then run `gitgo user login` again.
 
-Then run `gitgo user login` again.
+- **Linux and macOS**: Run this in your terminal:
+  ```bash
+  eval $(ssh-agent) && ssh-add
+  ```
+  Then run `gitgo user login` again.
 
 **Is your network blocking SSH?**
 Some office or school networks block SSH connections. Try a different network like your phone's hotspot. To test the connection manually, run:
@@ -163,6 +170,15 @@ ssh -T git@github.com
 ```
 
 If it works, you will see something like: `Hi username! You've successfully authenticated...`
+
+---
+
+## Commit Signing Sanitization
+
+If you have global Git commit signing enabled (`commit.gpgsign` is `true`), but do not have an active GPG configuration, commits might fail. 
+
+To prevent this, GitGo automatically inspects your Git config during login and before every commit. If it detects that GPG signing is enabled without a configured SSH signing key format, it temporarily disables conflicting global GPG configurations by unsetting `gpg.program`. This ensures your commit flow remains uninterrupted.
+
 
 ---
 

--- a/src/pygitgo/auth/account.py
+++ b/src/pygitgo/auth/account.py
@@ -65,3 +65,29 @@ def ensure_user_configure(default_email=None, default_username=None):
     error("Invalid configuration. Name and Email are required.")
     return False
 
+def sanitize_signing_config():
+    try:
+        gpgsign = run_command(["git", "config", "--global", "commit.gpgsign"]).strip().lower()
+    except GitCommandError:
+        return
+    
+    if gpgsign != "true":
+        return
+    
+    try:
+        fmt = run_command(["git", "config", "--global", "gpg.format"]).strip().lower()
+    except GitCommandError:
+        fmt = ""
+
+    if fmt == "ssh":
+        return
+    
+    warning("Detected 'commit.gpgsign=true' with no GPG key configured.")
+    warning("Disabling global GPG signing to prevent commit failures.")
+
+    try:
+        run_command(["git", "config", "--global", "--unset", "gpg.program"])
+    except GitCommandError:
+        pass
+    
+

--- a/src/pygitgo/auth/manager.py
+++ b/src/pygitgo/auth/manager.py
@@ -1,4 +1,5 @@
 from pygitgo.utils.colors import info, success, warning, error
+from pygitgo.utils.platform import get_platform
 from pygitgo.utils.executor import run_command
 from pygitgo.exceptions import GitCommandError
 from pygitgo.utils.platform import open_url
@@ -6,69 +7,101 @@ from . import ssh_utils
 import os
 
 
+def _configure_ssh_signing(key_path):
+    try:
+        run_command(["git", "config", "--global", "gpg.format", "ssh"])
+        run_command(["git", "config", "--global", "user.signingkey", str(key_path)])
+    except Exception:
+        pass
+    
+
 def login():
+    from .account import sanitize_signing_config, ensure_user_configure
+
+    sanitize_signing_config()
+
     if ssh_utils.check_connection():
-        success("You are already logged in!")
+        key_path = ssh_utils.get_ssh_key_path()
+
+        if key_path.exists():
+            _configure_ssh_signing(key_path)
+            ensure_user_configure(default_username=ssh_utils.get_github_username())
+            success("You are already logged in via GitGo.")
+        else:
+            warning("GitHub SSH connection is active, but NOT via a GitGo-managed key.")
+            warning("To use GitGo's full login (SSH + verified commits), you must log out first.")
+            info("Run: gitgo user logout")
+            info("Then run: gitgo user login")
+
         return True
-
-    info("initiating login sequence...")
-
+    
+    info("Initiating login sequence...")
     while True:
         email = input("Enter your email for GitHub: ").strip()
         if "@" in email and "." in email:
             break
         else:
             error("Please enter a valid email address.")
-        
 
     key_path = ssh_utils.generate_ssh_key(email=email)
     pub_key_path = str(key_path) + ".pub"
 
-    with open(pub_key_path, 'r') as f:
+    with open(pub_key_path, "r") as f:
         pub_key = f.read()
 
-    if pub_key:
-        success("SSH Key generated successfully!")
-
-        print("\n" + "=" * len(pub_key))
-        print(pub_key, end='')
-        print("=" * len(pub_key) + "\n")
-        
-        info("Copy the key above (between the lines).")
-        info("You need to add this key TWICE on GitHub:")
-        info("  1. Once as 'Authentication Key'  (so you can push and pull)")
-        info("  2. Once as 'Signing Key'          (so your commits show as Verified)")
-        info("Both entries use the exact same key text.")
-
-        open_url("https://github.com/settings/ssh/new")
-        
-        input(
-            "After adding both keys on GitHub,\n"
-            "come back here and press Enter to verify the connection..."
-        )
-
-    else:
+    if not pub_key:
         error("Failed to read the generated public key.")
         return False
 
+    success("SSH Key generated successfully!")
+
+    print()
+    print("  Your SSH public key:")
+    print()
+    print(f"  {pub_key.strip()}")
+    print()
+
+    info("Copy the key above, then add it TWICE on GitHub:")
+    info("  1. Authentication Key  — for pushing and pulling")
+    info("  2. Signing Key         — for Verified commits")
+    info("Same key text for both.")
+
+    input("\nOnce you've copied the key, press Enter to open GitHub...")
+
+    open_url("https://github.com/settings/ssh/new")
+
+    input(
+        "\nAfter adding both keys on GitHub,\n"
+        "come back here and press Enter to verify the connection..."
+    )
+
+    ssh_utils.ensure_ssh_agent(ssh_utils.get_ssh_key_path())
+
+    ssh_utils.clear_ssh_cache()
+
     if ssh_utils.check_connection():
-        from .account import ensure_user_configure
-        
         github_username = ssh_utils.get_github_username()
-
         ensure_user_configure(default_email=email, default_username=github_username)
-
         success("\nLogin Successful! You are connected.\n")
         return True
     
     error("Login Failed. The SSH key may not have been added to GitHub correctly.")
     info("Possible causes:")
     info("  1. The key was not pasted on GitHub")
-    info("  2. SSH agent is not running (try: eval $(ssh-agent) && ssh-add)")
+
+    if get_platform() == "windows":
+        info("  2. SSH agent is not running — run in PowerShell (as Administrator):")
+        info("       Set-Service ssh-agent -StartupType Automatic")
+        info("       Start-Service ssh-agent")
+        info("     Then run 'gitgo user login' again.")
+    else:
+        info("  2. SSH agent is not running (try: eval $(ssh-agent) && ssh-add)")
+        
     info("  3. Network or firewall is blocking SSH connections")
     info("Need help? Full guide: https://github.com/Huerte/GitGo/blob/main/docs/login-guide.md")
     return False
-    
+
+ 
 def logout():
     key_path = ssh_utils.get_ssh_key_path()
     if not key_path.exists():

--- a/src/pygitgo/auth/manager.py
+++ b/src/pygitgo/auth/manager.py
@@ -20,13 +20,14 @@ def login():
 
     sanitize_signing_config()
 
-    if ssh_utils.check_connection():
-        key_path = ssh_utils.get_ssh_key_path()
+    key_path = ssh_utils.get_ssh_key_path()
+    already_logged_in = key_path.exists()
+    ok_text = "Already logged in via GitGo." if already_logged_in else "GitHub connection verified."
 
-        if key_path.exists():
+    if ssh_utils.check_connection(ok_text=ok_text):
+        if already_logged_in:
             _configure_ssh_signing(key_path)
             ensure_user_configure(default_username=ssh_utils.get_github_username())
-            success("You are already logged in via GitGo.")
         else:
             warning("GitHub SSH connection is active, but NOT via a GitGo-managed key.")
             warning("To use GitGo's full login (SSH + verified commits), you must log out first.")
@@ -79,10 +80,9 @@ def login():
 
     ssh_utils.clear_ssh_cache()
 
-    if ssh_utils.check_connection():
+    if ssh_utils.check_connection(ok_text="Login successful. You are connected.", fail_text="SSH key not recognised by GitHub."):
         github_username = ssh_utils.get_github_username()
         ensure_user_configure(default_email=email, default_username=github_username)
-        success("\nLogin Successful! You are connected.\n")
         return True
     
     error("Login Failed. The SSH key may not have been added to GitHub correctly.")

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -1,13 +1,18 @@
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.colors import info, success, warning
+from pygitgo.utils.platform import get_platform
 from pygitgo.utils.executor import run_command
 from pathlib import Path
 import subprocess
+import time
 import os
 import re
 
 
 SSH_TIMEOUT_SECONDS = 10
+
+_cached_ssh_response = None
+_cache_populated = False
 
 
 def ensure_github_known_host():
@@ -47,13 +52,42 @@ def _get_github_ssh_response():
     except (subprocess.TimeoutExpired, OSError):
         return None
 
+
+def _get_cached_ssh_response():
+    global _cached_ssh_response, _cache_populated
+    if not _cache_populated:
+        _cached_ssh_response = _get_github_ssh_response()
+        _cache_populated = True
+    return _cached_ssh_response
+
+
+def clear_ssh_cache():
+    global _cached_ssh_response, _cache_populated
+    _cached_ssh_response = None
+    _cache_populated = False
+
+
 def check_connection():
+    from yaspin import yaspin
+
     ensure_github_known_host()
-    output = _get_github_ssh_response()
-    return output is not None and "successfully authenticated" in output
+
+    spinner = yaspin(text="Verifying GitHub connection...", color="cyan")
+    spinner.start()
+
+    output = _get_cached_ssh_response()
+    connected = output is not None and "successfully authenticated" in output
+
+    if connected:
+        spinner.ok("✔")
+    else:
+        spinner.fail("✖")
+
+    return connected
+
 
 def get_github_username():
-    output = _get_github_ssh_response()
+    output = _get_cached_ssh_response()
     if output and "Hi " in output and "!" in output:
         try:
             return output.split("Hi ")[1].split("!")[0]
@@ -92,10 +126,8 @@ def generate_ssh_key(email):
             "\nFailed to generate SSH key. Is 'ssh-keygen' installed on your system?\n"
             f"Details: {e}"
         )
-    try:
-        run_command(["ssh-add", str(key_path)])
-    except (GitCommandError, OSError):
-        pass 
+    
+    ensure_ssh_agent(key_path)
     
     return key_path
 
@@ -114,3 +146,42 @@ def convert_https_to_ssh(url):
 
 def is_ssh_url(url):
     return url.strip().startswith("git@")
+
+def _try_ssh_add(key_path):
+    try:
+        run_command(["ssh-add", str(key_path)])
+        return True
+    except (GitCommandError, OSError):
+        return False
+
+def ensure_ssh_agent(key_path):
+    if _try_ssh_add(key_path):
+        return True
+    
+    if get_platform() == "windows":
+        try:
+            subprocess.run(
+                ["sc", "start", "ssh-agent"],
+                capture_output=True, timeout=5
+            )
+        except Exception:
+            pass
+
+        time.sleep(1)
+
+        if _try_ssh_add(key_path):
+            return True
+        
+        warning("SSH agent is not running on this machine.")
+        info("To fix this permanently, run in PowerShell (as Administrator):")
+        info("  Set-Service ssh-agent -StartupType Automatic")
+        info("  Start-Service ssh-agent")
+        info("Then run 'gitgo user login' again.")
+
+    else:
+        warning("SSH agent is not running.")
+        info("Run:  eval $(ssh-agent) && ssh-add")
+        info("Then run 'gitgo user login' again.")
+
+    return False
+    

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -67,20 +67,28 @@ def clear_ssh_cache():
     _cache_populated = False
 
 
-def check_connection():
+def check_connection(ok_text=None, fail_text=None):
     from yaspin import yaspin
-
+    import sys
+    
     ensure_github_known_host()
 
-    spinner = yaspin(text="Verifying GitHub connection...", color="cyan")
+    kwargs = {"text": ok_text or "Verifying GitHub connection..."}
+    if sys.stdout.isatty():
+        kwargs["color"] = "cyan"
+    spinner = yaspin(**kwargs)
     spinner.start()
 
     output = _get_cached_ssh_response()
     connected = output is not None and "successfully authenticated" in output
 
     if connected:
+        if ok_text:
+            spinner.text = ok_text
         spinner.ok("✔")
     else:
+        if fail_text:
+            spinner.text = fail_text
         spinner.fail("✖")
 
     return connected

--- a/src/pygitgo/commands/git_branch.py
+++ b/src/pygitgo/commands/git_branch.py
@@ -30,11 +30,11 @@ def is_branch_exist(branch):
     return bool(run_command(["git", "branch", "-r", "--list", f"*/{branch}"])) or bool(run_command(["git", "branch", "--list", branch]))
 
 
-def git_new_branch(branch):
+def git_new_branch(branch, ok_text=None):
     try:
-        run_command(["git", "checkout", "-b", branch], loading_msg=f"Creating branch '{branch}'...")
-        print()
-        success(f"Branch '{branch}' created.")
+        if not ok_text:
+            ok_text = f"Branch '{branch}' created."
+        run_command(["git", "checkout", "-b", branch], loading_msg=f"Creating branch '{branch}'...", ok_text=ok_text)
     except GitCommandError:
         try:
             current = get_current_branch()

--- a/src/pygitgo/commands/git_core.py
+++ b/src/pygitgo/commands/git_core.py
@@ -19,7 +19,7 @@ def _get_signing_flags():
     ]
 
 
-def git_commit(commit_message, loading_msg="Commiting changes...", skip_staging=False):
+def git_commit(commit_message, loading_msg="Commiting changes...", skip_staging=False, ok_text=None):
     try:
         status_result = run_command(["git", "status", "--porcelain"])
         if not status_result.strip():
@@ -36,29 +36,31 @@ def git_commit(commit_message, loading_msg="Commiting changes...", skip_staging=
 
     signing_flags = _get_signing_flags()
     commit_command = ["git"] + signing_flags + ["commit", "-S", "-m", clean_message]
-    run_command(commit_command, loading_msg=loading_msg)
+    run_command(commit_command, loading_msg=loading_msg, ok_text=ok_text)
 
     return True
 
 
-def git_init():
+def git_init(ok_text=None):
     if os.path.isdir(".git"):
         warning("Already a git repository! Skipping init...")
         return False
 
     default_main_branch = get_default_branch()
 
+    if not ok_text:
+        ok_text = "Git repository initialized."
+
     try:
-        run_command(["git", "init", "-b", default_main_branch], loading_msg="Initializing git repository...")
+        run_command(["git", "init", "-b", default_main_branch], loading_msg="Initializing git repository...", ok_text=ok_text)
     except GitCommandError:
         run_command(["git", "init"], loading_msg="Initializing git repository...")
-        run_command(["git", "checkout", "-b", default_main_branch])
+        run_command(["git", "checkout", "-b", default_main_branch], ok_text=ok_text)
 
-    success("Git repository initialized.")
     return True
 
 
-def git_push(branch):
+def git_push(branch, ok_text=None):
     try:
         remote_url = run_command(["git", "remote", "get-url", "origin"]).strip()
     except GitCommandError:
@@ -67,13 +69,11 @@ def git_push(branch):
     if remote_url and not is_ssh_url(remote_url) and check_connection():
         ssh_url = convert_https_to_ssh(remote_url)
         if ssh_url:
-            run_command(["git", "remote", "set-url", "origin", ssh_url], loading_msg="Converting remote from HTTPS to SSH for secure push...")
-            success(f"Remote updated to: {ssh_url}")
+            run_command(["git", "remote", "set-url", "origin", ssh_url], loading_msg="Converting remote from HTTPS to SSH for secure push...", ok_text=f"Remote updated to: {ssh_url}")
 
     try:
-        run_command(["git", "push", "-u", "origin", branch], loading_msg=f"Pushing to remote branch '{branch}'...")
+        run_command(["git", "push", "-u", "origin", branch], loading_msg=f"Pushing to remote branch '{branch}'...", ok_text=ok_text, err_text="Push failed: verify your remote URL and SSH key, then try again.")
     except (GitCommandError, OSError) as e:
-        error("Push failed — verify your remote URL and SSH key, then try again.")
         info("Run:  git remote -v   to inspect your current remote.")
         if "rebase in progress" in str(e):
             handle_rebase()

--- a/src/pygitgo/commands/git_core.py
+++ b/src/pygitgo/commands/git_core.py
@@ -1,6 +1,7 @@
 from pygitgo.auth.ssh_utils import convert_https_to_ssh, get_ssh_key_path, is_ssh_url, check_connection
 from pygitgo.utils.colors import info, success, warning, error
 from pygitgo.exceptions import GitGoError, GitCommandError
+from pygitgo.auth.account import sanitize_signing_config
 from pygitgo.commands.git_remote import handle_rebase
 from pygitgo.utils.config import get_default_branch
 from pygitgo.utils.executor import run_command
@@ -25,6 +26,8 @@ def git_commit(commit_message, loading_msg="Commiting changes...", skip_staging=
             return False
     except GitCommandError:
         return False
+    
+    sanitize_signing_config()
 
     if not skip_staging:
         run_command(["git", "add", "."], loading_msg="Staging files...")

--- a/src/pygitgo/commands/git_remote.py
+++ b/src/pygitgo/commands/git_remote.py
@@ -9,17 +9,16 @@ def add_remote_origin(repo_url):
     try:
         existing_remote = run_command(["git", "remote", "get-url", "origin"])
         warning(f"Remote origin already exists: {existing_remote}")
-        run_command(["git", "remote", "set-url", "origin", clean_url], loading_msg="Updating remote URL...")
+        run_command(["git", "remote", "set-url", "origin", clean_url], loading_msg="Updating remote URL...", ok_text=f"Remote origin set to: {clean_url}")
     except GitCommandError:
-        run_command(["git", "remote", "add", "origin", clean_url], loading_msg="Adding remote origin...")
-
-    success(f"Remote origin set to: {clean_url}")
+        run_command(["git", "remote", "add", "origin", clean_url], loading_msg="Adding remote origin...", ok_text=f"Remote origin set to: {clean_url}")
 
 
-def confirm_remote_link():
+def confirm_remote_link(ok_text=None):
     try:
-        run_command(["git", "ls-remote", "origin"], loading_msg="Testing connection to remote...")
-        success("Remote is reachable.")
+        if not ok_text:
+            ok_text = "Remote is reachable."
+        run_command(["git", "ls-remote", "origin"], loading_msg="Testing connection to remote...", ok_text=ok_text)
         return True
     except GitCommandError:
         error("Connection failed — verify the URL and your SSH key.")
@@ -44,14 +43,13 @@ def check_and_sync_branch(branch):
                 )
                 if behind_check and int(behind_check) > 0:
                     warning(f"Local branch is behind remote by {behind_check} commit(s). Pulling changes...")
-                    output = run_command(["git", "pull", "--rebase", "origin", branch], loading_msg="Pulling changes from remote...")
+                    output = run_command(["git", "pull", "--rebase", "origin", branch], loading_msg="Pulling changes from remote...", ok_text="Synced with remote.")
                     if output:
                         print(output)
-                    success("Synced with remote.")
                 else:
-                    success("Branch is up to date.")
+                    info("Branch is up to date.")
             else:
-                success("Branch is already up to date.")
+                info("Branch is already up to date.")
         except (GitCommandError, ValueError):
             warning("Remote branch doesn't exist yet. First push will create it.")
     except (GitCommandError, OSError):

--- a/src/pygitgo/commands/init.py
+++ b/src/pygitgo/commands/init.py
@@ -172,19 +172,31 @@ def _parse_template_slug(template):
 
 
 def _download_and_extract_template(template_slug, target_dir):
+    from yaspin import yaspin
+    import sys
     url = f"https://api.github.com/repos/{template_slug}/zipball"
     req = urllib.request.Request(url, headers={"User-Agent": "GitGo-CLI"})
-    info(f"Downloading template from GitHub: {template_slug}...")
+    kwargs = {"text": f"Downloading template from GitHub: {template_slug}..."}
+    if sys.stdout.isatty():
+        kwargs["color"] = "cyan"
+    spinner = yaspin(**kwargs)
+    spinner.start()
     try:
         with urllib.request.urlopen(req, timeout=30) as response:
             zip_data = response.read()
     except urllib.error.HTTPError as e:
         if e.code == 404:
+            spinner.text = f"Template '{template_slug}' not found on GitHub."
+            spinner.fail("✖")
             raise GitGoError(
                 f"Template repository '{template_slug}' not found on GitHub."
             )
+        spinner.text = f"Failed to download template: HTTP {e.code}"
+        spinner.fail("✖")
         raise GitGoError(f"Failed to download template: HTTP {e.code}")
     except Exception as e:
+        spinner.text = f"Network error downloading template: {e}"
+        spinner.fail("✖")
         raise GitGoError(f"Network error downloading template: {e}")
 
     try:
@@ -207,8 +219,11 @@ def _download_and_extract_template(template_slug, target_dir):
                     os.makedirs(os.path.dirname(dest), exist_ok=True)
                     with zf.open(member) as src, open(dest, "wb") as out:
                         out.write(src.read())
-        success("Template extracted successfully.")
+        spinner.text = "Template extracted successfully."
+        spinner.ok("✔")
     except Exception as e:
+        spinner.text = f"Failed to extract template: {e}"
+        spinner.fail("✖")
         raise GitGoError(f"Failed to extract template: {e}")
 
 
@@ -294,9 +309,8 @@ def init_operation(args):
             _scaffold_language(args.lang, target_dir, target_dir)
 
         os.chdir(target_dir)
-        git_init()
+        git_init(ok_text=f"Initialized empty Git repository in {os.path.abspath('.')}")
 
-        success(f"\nInitialized empty Git repository in {os.path.abspath('.')}")
         info("Next step: Create a remote repo with 'gitgo new <name>'")
 
     except Exception as e:

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -14,21 +14,19 @@ def undo_jump_operation(original_branch, stashed_code, created_branch=None):
     if created_branch:
         run_command(["git", "checkout", original_branch], loading_msg=f"Jumping you back to the original branch '{original_branch}'...")
         try:
-            run_command(["git", "branch", "-D", created_branch], loading_msg=f"Removing the empty branch '{created_branch}'...")
+            ok_text = None if stashed_code else f"Canceled safely. Back on '{original_branch}'."
+            run_command(["git", "branch", "-D", created_branch], loading_msg=f"Removing the empty branch '{created_branch}'...", ok_text=ok_text)
         except GitCommandError:
             warning(f"Could not delete branch '{created_branch}'. Remove it manually with: git branch -D {created_branch}")
     else:
         run_command(["git", "reset", "--hard", "HEAD"], loading_msg="Canceling... Putting your files back exactly how they were...")
-        run_command(['git', 'checkout', original_branch], loading_msg=f"Jumping you back to the original branch '{original_branch}'...")
+        ok_text = None if stashed_code else f"Canceled safely. Back on '{original_branch}'."
+        run_command(['git', 'checkout', original_branch], loading_msg=f"Jumping you back to the original branch '{original_branch}'...", ok_text=ok_text)
 
     if stashed_code:
-        pop_result = git_stash_pop()
+        pop_result = git_stash_pop(ok_text=f"Canceled safely. Back on '{original_branch}'. Your code is safe.")
         if not pop_result:
             warning("Could not restore your unsaved changes automatically. Run 'gitgo state list' to recover them.")
-
-    print()
-    success(f"Canceled safely.")
-    success(f"Back on '{original_branch}'. Your code is safe.")
 
 
 def _jump_interrupt_cleanup(original_branch, stashed_code, created_branch):
@@ -52,10 +50,8 @@ def _jump_interrupt_cleanup(original_branch, stashed_code, created_branch):
             if stashed_code:
                 warning("Then restore your stash: git stash pop")
     elif stashed_code:
-        pop_result = git_stash_pop()
-        if pop_result:
-            success("Your stashed changes have been restored.")
-        else:
+        pop_result = git_stash_pop(ok_text="Your stashed changes have been restored.")
+        if not pop_result:
             warning("Could not restore stash automatically. Run 'gitgo state list' to find it.")
     else:
         success("No git state was changed. Your files are safe.")
@@ -107,18 +103,26 @@ def jump_operation(args):
                         warning("Could not restore your unsaved changes automatically. Run 'gitgo state list' to recover them.")
                 return
 
-            git_new_branch(target_branch)
+            ok_text = f"Branch '{target_branch}' created." if stashed_code else f"On '{target_branch}'."
+            git_new_branch(target_branch, ok_text=ok_text)
             created_branch = target_branch
         else:
-            run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...")
-
-            main_branch = get_main_branch()
-
-            try:
-                run_command(['git', 'pull', 'origin', main_branch], loading_msg=f"Downloading the latest updates from '{main_branch}'...")
-            except GitCommandError:
-                warning(f"Failed to pull updates from '{main_branch}'. No internet, or the remote branch doesn't exist yet.")
-                info(f"On '{target_branch}', but without the latest updates from '{main_branch}'.")
+            if stashed_code:
+                run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...", ok_text=f"Moved to branch '{target_branch}'.")
+                main_branch = get_main_branch()
+                try:
+                    run_command(['git', 'pull', 'origin', main_branch], loading_msg=f"Downloading the latest updates from '{main_branch}'...", ok_text=f"Downloaded updates from '{main_branch}'.")
+                except GitCommandError:
+                    warning(f"Failed to pull updates from '{main_branch}'. No internet, or the remote branch doesn't exist yet.")
+                    info(f"On '{target_branch}', but without the latest updates from '{main_branch}'.")
+            else:
+                run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...", ok_text=f"Moved to branch '{target_branch}'.")
+                main_branch = get_main_branch()
+                try:
+                    run_command(['git', 'pull', 'origin', main_branch], loading_msg=f"Downloading the latest updates from '{main_branch}'...", ok_text=f"On '{target_branch}'. Up to date with '{main_branch}'.")
+                except GitCommandError:
+                    warning(f"Failed to pull updates from '{main_branch}'. No internet, or the remote branch doesn't exist yet.")
+                    info(f"On '{target_branch}', but without the latest updates from '{main_branch}'.")
 
         if stashed_code:
             apply_result = git_stash_apply(loading_msg="Unpacking your unsaved changes...")
@@ -141,15 +145,11 @@ def jump_operation(args):
                     info("Your stash backup is still saved. Run 'gitgo state list' to see it.")
                     return
             else:
-                drop_result = git_stash_drop(loading_msg="Cleaning up the temporary stash...")
+                drop_result = git_stash_drop(loading_msg="Cleaning up the temporary stash...", ok_text=f"On '{target_branch}'. Your changes came with you.")
                 if not drop_result:
                     warning("Could not clean up the temporary stash. Run 'gitgo state list' to remove it manually.")
-                print()
-                success(f"On '{target_branch}'. Your changes came with you.")
                 return
         else:
-            print()
-            success(f"On '{target_branch}'.")
             return
 
     except KeyboardInterrupt:

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -55,15 +55,13 @@ def link_core(repo_url, commit_message="Initial commit", silent=False, already_i
             add_remote_origin(repo_url)
             remote_added = True
 
-            if confirm_remote_link():
-                success("\nRemote linked to existing repository.")
-                success(f"Ready to push with: gitgo push <branch> 'your message'\n")
+            if confirm_remote_link(ok_text="Remote linked to existing repository."):
+                info("Ready to push with: gitgo push <branch> 'your message'")
             return
 
-        commit_made = git_commit(commit_message, loading_msg="Creating initial commit...")
+        commit_made = git_commit(commit_message, loading_msg="Creating initial commit...", ok_text="Initial commit created.")
         if commit_made:
             committed = True
-            success("Initial commit created.")
 
         add_remote_origin(repo_url)
         remote_added = True
@@ -87,9 +85,9 @@ def link_core(repo_url, commit_message="Initial commit", silent=False, already_i
             try:
                 run_command(
                     ["git", "pull", "origin", main_branch, "--allow-unrelated-histories", "--no-edit"],
-                    loading_msg="Pulling and merging remote content..."
+                    loading_msg="Pulling and merging remote content...",
+                    ok_text="Remote content merged."
                 )
-                success("Remote content merged.")
             except GitCommandError:
                 error("Failed to merge remote content. You may need to resolve conflicts manually.")
                 warning(f"Run: git pull origin {main_branch} --allow-unrelated-histories")

--- a/src/pygitgo/commands/pull.py
+++ b/src/pygitgo/commands/pull.py
@@ -15,8 +15,7 @@ def _pull_interrupt_cleanup():
     if rebase_in_progress:
         warning("A rebase is in progress from the interrupted pull.")
         try:
-            run_command(["git", "rebase", "--abort"], loading_msg="Aborting interrupted rebase...")
-            success("Rebase aborted. Branch is back to its pre-pull state.")
+            run_command(["git", "rebase", "--abort"], loading_msg="Aborting interrupted rebase...", ok_text="Rebase aborted. Branch is back to its pre-pull state.")
         except GitCommandError:
             error("Could not abort rebase automatically.")
             info("Run manually: git rebase --abort")
@@ -49,10 +48,9 @@ def pull_operation(args):
 
         run_command(
             ["git", "pull", "--rebase", "--autostash", "origin", branch],
-            loading_msg=f"Downloading latest updates for '{branch}' (auto-saving your code)..."
+            loading_msg=f"Downloading latest updates for '{branch}' (auto-saving your code)...",
+            ok_text=f"Project is up to date with '{branch}'."
         )
-
-        success(f"Project is up to date with '{branch}'.")
 
     except KeyboardInterrupt:
         print()

--- a/src/pygitgo/commands/repo.py
+++ b/src/pygitgo/commands/repo.py
@@ -118,15 +118,30 @@ def repo_operation(args, silent=False):
         info(f"No name given: using current directory name: '{repo_name}'")
 
     token = _get_github_token()
-    info(f"Creating GitHub repository '{repo_name}'...")
-    repo_ = create_github_repo(
-        name=repo_name,
-        private=args.private,
-        description=args.description or "",
-        token=token
-    )
-    repo_url = repo_.get("clone_url")
-    success(f"Successfully created remote repository: {repo_url}")
+
+    from yaspin import yaspin
+    import sys
+    kwargs = {"text": f"Creating GitHub repository '{repo_name}'..."}
+    if sys.stdout.isatty():
+        kwargs["color"] = "cyan"
+    spinner = yaspin(**kwargs)
+    spinner.start()
+
+    try:
+        repo_ = create_github_repo(
+            name=repo_name,
+            private=args.private,
+            description=args.description or "",
+            token=token
+        )
+        repo_url = repo_.get("clone_url")
+        spinner.text = f"Successfully created remote repository: {repo_url}"
+        spinner.ok("✔")
+    except Exception as e:
+        spinner.text = str(e)
+        spinner.fail("✖")
+        raise e
+
     if not silent:
         info(f"\nTo connect and push your local code, run:\n  gitgo link {repo_url}")
     return repo_url

--- a/src/pygitgo/commands/stash.py
+++ b/src/pygitgo/commands/stash.py
@@ -1,11 +1,12 @@
 from pygitgo.utils.executor import run_command
 from pygitgo.exceptions import GitCommandError
 
-def git_stash_push(label="GitGo Auto-Stash", loading_msg="Saving your changes..."):
+def git_stash_push(label="GitGo Auto-Stash", loading_msg="Saving your changes...", ok_text=None):
     try:
         result = run_command(
             ["git", "stash", "push", "-u", "-m", label],
-            loading_msg=loading_msg
+            loading_msg=loading_msg,
+            ok_text=ok_text
         )
 
         if isinstance(result, str) and "No local changes to save" in result:
@@ -17,53 +18,54 @@ def git_stash_push(label="GitGo Auto-Stash", loading_msg="Saving your changes...
         return False
     
 
-def git_stash_pop(loading_msg="Restoring your saved changes..."):
+def git_stash_pop(loading_msg="Restoring your saved changes...", ok_text=None):
     try:
         run_command(
             ["git", "stash", "pop"], 
-            loading_msg=loading_msg
+            loading_msg=loading_msg,
+            ok_text=ok_text
         )
         return True
     except GitCommandError:
         return False
 
 
-def git_stash_apply(stash_id=None, loading_msg="Applying saved changes..."):
+def git_stash_apply(stash_id=None, loading_msg="Applying saved changes...", ok_text=None):
     command = ["git", "stash", "apply"]
     if stash_id is not None:
         command.append(f"stash@{{{stash_id}}}")
 
     try:
-        run_command(command, loading_msg=loading_msg)
+        run_command(command, loading_msg=loading_msg, ok_text=ok_text)
         return True
     except GitCommandError:
         return False
 
 
-def git_stash_drop(stash_id=None, loading_msg="Cleaning up stash..."):
+def git_stash_drop(stash_id=None, loading_msg="Cleaning up stash...", ok_text=None):
     command = ["git", "stash", "drop"]
     if stash_id is not None:
         command.append(f"stash@{{{stash_id}}}")
 
     try:
-        run_command(command, loading_msg=loading_msg)
+        run_command(command, loading_msg=loading_msg, ok_text=ok_text)
         return True
     except GitCommandError:
         return False
 
-def git_stash_list(loading_msg="Fetching stash list..."):
+def git_stash_list(loading_msg="Fetching stash list...", ok_text=None):
     try:
         return run_command([
             "git", "stash", "list",
             "--date=format:%Y-%m-%d %H:%M:%S",
             "--pretty=%gd||%cd||%s"
-        ], loading_msg=loading_msg)
+        ], loading_msg=loading_msg, ok_text=ok_text)
     except GitCommandError:
         return ""
 
-def git_stash_clear(loading_msg="Clearing all stashes..."):
+def git_stash_clear(loading_msg="Clearing all stashes...", ok_text=None):
     try:
-        run_command(["git", "stash", "clear"], loading_msg=loading_msg)
+        run_command(["git", "stash", "clear"], loading_msg=loading_msg, ok_text=ok_text)
         return True
     except GitCommandError:
         return False

--- a/src/pygitgo/commands/undo.py
+++ b/src/pygitgo/commands/undo.py
@@ -32,16 +32,14 @@ def undo_changes():
     try:
         run_command(["git", "reset", "--hard", "HEAD"], loading_msg="Throwing away edits...")
         reset_done = True
-        run_command(["git", "clean", "-fd"], loading_msg="Removing new files...")
-        success("Working tree reset. All changes discarded.")
+        run_command(["git", "clean", "-fd"], loading_msg="Removing new files...", ok_text="Working tree reset. All changes discarded.")
 
     except KeyboardInterrupt:
         print()
         if reset_done:
             warning("Interrupted during file removal. Finishing cleanup...")
             try:
-                run_command(["git", "clean", "-fd"])
-                success("Working tree reset. All changes discarded.")
+                run_command(["git", "clean", "-fd"], loading_msg="Removing new files...", ok_text="Working tree reset. All changes discarded.")
             except GitCommandError:
                 warning("Could not finish cleanup. Run 'git clean -fd' manually.")
         else:
@@ -87,9 +85,9 @@ def undo_push():
     try:
         run_command(
             ["git", "push", "--force", "origin", branch],
-            loading_msg=f"Force-pushing reverted state to '{branch}'..."
+            loading_msg=f"Force-pushing reverted state to '{branch}'...",
+            ok_text=f"Last push reverted. Remote '{branch}' is back to the previous commit."
         )
-        success(f"Last push reverted. Remote '{branch}' is back to the previous commit.")
         info("Your files are still staged locally. Edit and push again when ready.")
     except GitCommandError as e:
         warning("Local commit was undone, but the force-push failed.")

--- a/src/pygitgo/exceptions.py
+++ b/src/pygitgo/exceptions.py
@@ -3,7 +3,6 @@ class GitGoError(Exception):
 
 
 class GitCommandError(GitGoError):
-    """Raised when a git subprocess command fails."""
     def __init__(self, command, stderr="", returncode=1):
         self.command = command
         self.stderr = stderr

--- a/src/pygitgo/utils/bootstrap.py
+++ b/src/pygitgo/utils/bootstrap.py
@@ -1,12 +1,9 @@
 from pygitgo.exceptions import GitGoError
-from pygitgo.auth.ssh_utils import ensure_github_known_host
-from pygitgo.utils.config import get_config, set_config
 from pygitgo.utils.colors import error, info
 import shutil
 
 
 def check_git_installed():
-    """Verify that Git is installed and available on PATH."""
     if not shutil.which("git"):
         error("\nGit is not installed or not found on your PATH!")
         info("Install Git from: https://git-scm.com/downloads")
@@ -16,11 +13,3 @@ def check_git_installed():
 
 def ensure_first_run_setup():
     check_git_installed()
-
-    is_initialized = get_config("initialized", fallback_value="false")
-
-    if is_initialized == "false":
-        info("\nInitializing GitGo network settings for the first time... please wait.")
-        ensure_github_known_host()
-
-        set_config("initialized", "true")

--- a/src/pygitgo/utils/executor.py
+++ b/src/pygitgo/utils/executor.py
@@ -6,9 +6,13 @@ import os
 import re
 
 
-def run_command(command, return_complete=False, loading_msg=None):
+def run_command(command, return_complete=False, loading_msg=None, ok_text=None, err_text=None):
 
-    spinner = yaspin(text=loading_msg, color="cyan") if loading_msg else None
+    import sys
+    kwargs = {"text": loading_msg}
+    if sys.stdout.isatty():
+        kwargs["color"] = "cyan"
+    spinner = yaspin(**kwargs) if loading_msg else None
 
     if spinner:
         spinner.start()
@@ -22,11 +26,15 @@ def run_command(command, return_complete=False, loading_msg=None):
         )
 
         if spinner:
+            if ok_text:
+                spinner.text = ok_text
             spinner.ok("✔")
 
         return result if return_complete else result.stdout.strip()
     except (subprocess.CalledProcessError, OSError) as e:
         if spinner:
+            if err_text:
+                spinner.text = err_text
             spinner.fail("✖")
 
         stderr = ""

--- a/src/pygitgo/utils/validators.py
+++ b/src/pygitgo/utils/validators.py
@@ -2,7 +2,7 @@ import re
 
 
 def validate_repo_url(url):
-    """Validate that the URL looks like a valid Git repository URL."""
+    # Validate that the URL looks like a valid Git repository URL
     patterns = [
         r'^https?://[\w.-]+/[\w.-]+/[\w.-]+(?:\.git)?/?$',  # HTTPS
         r'^git@[\w.-]+:[\w.-]+/[\w.-]+(?:\.git)?$',          # SSH

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 import sys
 
 
@@ -16,3 +17,12 @@ def capture_system_exit_code(function):
         return e.code
     except GitGoError:
         return 1
+
+
+@pytest.fixture(autouse=True)
+def _clear_ssh_cache():
+    """Reset the SSH response cache before every test."""
+    from pygitgo.auth.ssh_utils import clear_ssh_cache
+    clear_ssh_cache()
+    yield
+    clear_ssh_cache()

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,6 +1,7 @@
 import pytest
 from pygitgo.exceptions import GitCommandError
-from pygitgo.auth.account import get_user, set_user, ensure_user_configure
+from pygitgo.auth.account import get_user, set_user, ensure_user_configure, sanitize_signing_config
+
 
 
 def test_get_user_both_exist(mocker):
@@ -72,3 +73,50 @@ def test_ensure_user_configure_prompt_failure(mocker):
     result = ensure_user_configure()
     assert result is False
     fake_set.assert_not_called()
+
+
+def test_sanitize_signing_config_disabled(mocker):
+    fake_run = mocker.patch("pygitgo.auth.account.run_command", return_value="false")
+    sanitize_signing_config()
+    fake_run.assert_called_once_with(["git", "config", "--global", "commit.gpgsign"])
+
+
+def test_sanitize_signing_config_not_configured(mocker):
+    fake_run = mocker.patch("pygitgo.auth.account.run_command", side_effect=GitCommandError(["git", "config"]))
+    sanitize_signing_config()
+    fake_run.assert_called_once_with(["git", "config", "--global", "commit.gpgsign"])
+
+
+def test_sanitize_signing_config_ssh_format(mocker):
+    fake_run = mocker.patch("pygitgo.auth.account.run_command", side_effect=["true", "ssh"])
+    sanitize_signing_config()
+    assert fake_run.call_count == 2
+    fake_run.assert_any_call(["git", "config", "--global", "commit.gpgsign"])
+    fake_run.assert_any_call(["git", "config", "--global", "gpg.format"])
+
+
+def test_sanitize_signing_config_unset_gpg_program(mocker):
+    fake_run = mocker.patch("pygitgo.auth.account.run_command", side_effect=["true", "openpgp", None])
+    fake_warning = mocker.patch("pygitgo.auth.account.warning")
+
+    sanitize_signing_config()
+
+    assert fake_run.call_count == 3
+    fake_run.assert_any_call(["git", "config", "--global", "commit.gpgsign"])
+    fake_run.assert_any_call(["git", "config", "--global", "gpg.format"])
+    fake_run.assert_any_call(["git", "config", "--global", "--unset", "gpg.program"])
+    assert fake_warning.call_count == 2
+
+
+def test_sanitize_signing_config_unset_gpg_program_error(mocker):
+    fake_run = mocker.patch(
+        "pygitgo.auth.account.run_command",
+        side_effect=["true", "openpgp", GitCommandError(["git", "config"])]
+    )
+    fake_warning = mocker.patch("pygitgo.auth.account.warning")
+
+    sanitize_signing_config()
+
+    assert fake_run.call_count == 3
+    assert fake_warning.call_count == 2
+

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -23,32 +23,7 @@ def test_check_git_installed_exist(mocker):
     fake_error.assert_not_called()
     fake_info.assert_not_called()
 
-def test_ensure_first_run_setup_already_initialized(mocker):
-    mocker.patch('pygitgo.utils.bootstrap.check_git_installed', return_value=None)
-    fake_get_config = mocker.patch('pygitgo.utils.bootstrap.get_config', return_value="ok")
-    fake_github_function = mocker.patch('pygitgo.utils.bootstrap.ensure_github_known_host', return_value=None)
-    fake_set_config = mocker.patch('pygitgo.utils.bootstrap.set_config', return_value=True)
-    fake_info = mocker.patch("pygitgo.utils.bootstrap.info")
-
+def test_ensure_first_run_setup(mocker):
+    fake_check = mocker.patch('pygitgo.utils.bootstrap.check_git_installed', return_value=None)
     ensure_first_run_setup()
-
-    fake_info.assert_not_called()
-    fake_github_function.assert_not_called()
-    fake_set_config.assert_not_called()
-
-    fake_get_config.assert_called_with("initialized", fallback_value="false")
-
-def test_ensure_first_run_setup_not_initialized(mocker):
-    mocker.patch('pygitgo.utils.bootstrap.check_git_installed', return_value=None)
-    fake_get_config = mocker.patch('pygitgo.utils.bootstrap.get_config', return_value="false")
-    fake_github_function = mocker.patch('pygitgo.utils.bootstrap.ensure_github_known_host', return_value=None)
-    fake_set_config = mocker.patch('pygitgo.utils.bootstrap.set_config', return_value=True)
-    fake_info = mocker.patch("pygitgo.utils.bootstrap.info")
-
-    ensure_first_run_setup()
-
-    fake_info.assert_called_with("\nInitializing GitGo network settings for the first time... please wait.")
-    fake_github_function.assert_called_once()
-    fake_set_config.assert_called_with("initialized", "true")
-
-    fake_get_config.assert_called_with("initialized", fallback_value="false")
+    fake_check.assert_called_once()

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -21,7 +21,7 @@ def test_config_operation_not_valid_keys(mocker):
 
 def test_config_operation_set_no_value(mocker):
     fake_error = mocker.patch('pygitgo.commands.config.error')
-    args = Namespace(key="default-branch", action="set") # value is missing
+    args = Namespace(key="default-branch", action="set")
     config_operation(args)
     fake_error.assert_called_with("\nYou must provide a value to set!\n")
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -57,10 +57,8 @@ def test_get_config_error_handling(mocker):
     assert result == "fallback"
 
 
-# --- get_default_branch tests ---
 
 def test_get_default_branch_uses_git_init_default_branch(mocker):
-    # Level 1: native git config wins over gitgo config and hard fallback.
     mocker.patch(
         "pygitgo.utils.config.subprocess.check_output",
         return_value="develop\n",
@@ -70,7 +68,6 @@ def test_get_default_branch_uses_git_init_default_branch(mocker):
 
 
 def test_get_default_branch_falls_back_to_gitgo_config(mocker):
-    # Level 2: init.defaultBranch unset, gitgo.default-branch is set.
     mocker.patch(
         "pygitgo.utils.config.subprocess.check_output",
         side_effect=subprocess.CalledProcessError(1, "git"),
@@ -81,7 +78,6 @@ def test_get_default_branch_falls_back_to_gitgo_config(mocker):
 
 
 def test_get_default_branch_hard_fallback_to_main(mocker):
-    # Level 3: both sources absent, returns "main".
     mocker.patch(
         "pygitgo.utils.config.subprocess.check_output",
         side_effect=subprocess.CalledProcessError(1, "git"),
@@ -93,7 +89,6 @@ def test_get_default_branch_hard_fallback_to_main(mocker):
 
 
 def test_get_default_branch_handles_git_not_found(mocker):
-    # FileNotFoundError when git is not on PATH should not crash.
     mocker.patch(
         "pygitgo.utils.config.subprocess.check_output",
         side_effect=FileNotFoundError,

--- a/tests/test_git_branch.py
+++ b/tests/test_git_branch.py
@@ -14,13 +14,14 @@ def test_git_branch_logic(mocker):
 
     fake_run.assert_called_once_with(
         ["git", "checkout", "-b", "hello-world"], 
-        loading_msg="Creating branch 'hello-world'..."
+        loading_msg="Creating branch 'hello-world'...",
+        ok_text="Branch 'hello-world' created."
     )
 
 def test_git_branch_exists_jump_yes(mocker):
     from pygitgo.exceptions import GitCommandError
     fake_run = mocker.patch("pygitgo.commands.git_branch.run_command", side_effect=GitCommandError(["git", "checkout", "-b"]))
-    mocker.patch("pygitgo.commands.git_branch.get_current_branch", return_value="main")  # different branch
+    mocker.patch("pygitgo.commands.git_branch.get_current_branch", return_value="main") 
     mocker.patch("builtins.input", return_value="y")
     fake_jump = mocker.patch("pygitgo.commands.jump.jump_operation")
     fake_error = mocker.patch("pygitgo.commands.git_branch.error")
@@ -38,7 +39,7 @@ def test_git_branch_exists_jump_yes(mocker):
 def test_git_branch_exists_jump_no(mocker):
     from pygitgo.exceptions import GitCommandError, GitGoError
     fake_run = mocker.patch("pygitgo.commands.git_branch.run_command", side_effect=GitCommandError(["git", "checkout", "-b"]))
-    mocker.patch("pygitgo.commands.git_branch.get_current_branch", return_value="main")  # different branch
+    mocker.patch("pygitgo.commands.git_branch.get_current_branch", return_value="main") 
     mocker.patch("builtins.input", return_value="n")
     fake_jump = mocker.patch("pygitgo.commands.jump.jump_operation")
     fake_error = mocker.patch("pygitgo.commands.git_branch.error")
@@ -62,8 +63,8 @@ def test_git_branch_already_on_target_skips_prompt(mocker):
     result = git_new_branch("feat/safe-interruptions")
 
     assert result == "feat/safe-interruptions"
-    fake_input.assert_not_called()  # no prompt shown
-    fake_jump.assert_not_called()   # no jump triggered
+    fake_input.assert_not_called()
+    fake_jump.assert_not_called() 
     fake_info.assert_called_once_with("Already on branch 'feat/safe-interruptions'. Continuing...")
 
 def test_get_current_branch(mocker):

--- a/tests/test_git_core.py
+++ b/tests/test_git_core.py
@@ -16,7 +16,8 @@ def test_git_commit(mocker):
 
     fake_run.assert_any_call(
         ['git', 'commit', '-S', '-m', 'Testing the commit feature'],
-        loading_msg="Commiting changes..."
+        loading_msg="Commiting changes...",
+        ok_text=None
     )
 
 def test_git_init_already_initialized(mocker):
@@ -33,23 +34,21 @@ def test_git_init_already_initialized(mocker):
 def test_git_init_success(mocker):
     mocker.patch('os.path.isdir', return_value=False)
     mocker.patch('pygitgo.commands.git_core.get_default_branch', return_value='main')
-    fake_success = mocker.patch('pygitgo.commands.git_core.success')
     fake_run = mocker.patch('pygitgo.commands.git_core.run_command', return_value='ok')
 
     result = git_init()
 
     assert result == True
-    fake_success.assert_called_once()
     fake_run.assert_called_once_with(
         ["git", "init", "-b", 'main'], 
-        loading_msg="Initializing git repository..."
+        loading_msg="Initializing git repository...",
+        ok_text="Git repository initialized."
     )
 
 def test_git_init_fallback(mocker):
     from pygitgo.exceptions import GitCommandError
     mocker.patch('os.path.isdir', return_value=False)
     mocker.patch('pygitgo.commands.git_core.get_default_branch', return_value='main')
-    fake_success = mocker.patch('pygitgo.commands.git_core.success')
     
     fake_run = mocker.patch(
         'pygitgo.commands.git_core.run_command', 
@@ -63,7 +62,6 @@ def test_git_init_fallback(mocker):
     result = git_init()
 
     assert result == True
-    fake_success.assert_called_once()
     assert fake_run.call_count == 3
 
 def test_git_push_already_ssh(mocker):
@@ -80,7 +78,9 @@ def test_git_push_already_ssh(mocker):
 
     fake_run.assert_called_with(
         ["git", "push", "-u", "origin", branch], 
-        loading_msg=f"Pushing to remote branch '{branch}'..."
+        loading_msg=f"Pushing to remote branch '{branch}'...",
+        ok_text=None,
+        err_text="Push failed: verify your remote URL and SSH key, then try again."
     )
 
 def test_git_push_no_remote(mocker):
@@ -98,7 +98,9 @@ def test_git_push_no_remote(mocker):
 
     fake_run.assert_called_with(
         ["git", "push", "-u", "origin", branch], 
-        loading_msg=f"Pushing to remote branch '{branch}'..."
+        loading_msg=f"Pushing to remote branch '{branch}'...",
+        ok_text=None,
+        err_text="Push failed: verify your remote URL and SSH key, then try again."
     )
 
 def test_git_push_https_no_connection(mocker):
@@ -112,16 +114,15 @@ def test_git_push_https_no_connection(mocker):
 
     mocker.patch('pygitgo.commands.git_core.is_ssh_url', return_value=False)
     mocker.patch('pygitgo.commands.git_core.check_connection', return_value=False)
-    fake_success = mocker.patch('pygitgo.commands.git_core.success')
     
     branch = 'main'
     git_push(branch)
 
-    fake_success.assert_not_called()
-
     fake_run.assert_called_with(
         ["git", "push", "-u", "origin", branch], 
-        loading_msg=f"Pushing to remote branch '{branch}'..."
+        loading_msg=f"Pushing to remote branch '{branch}'...",
+        ok_text=None,
+        err_text="Push failed: verify your remote URL and SSH key, then try again."
     )
 
 def test_git_push_convert_https_to_ssh(mocker):
@@ -137,21 +138,21 @@ def test_git_push_convert_https_to_ssh(mocker):
     mocker.patch('pygitgo.commands.git_core.is_ssh_url', return_value=False)
     mocker.patch('pygitgo.commands.git_core.check_connection', return_value=True)
     mocker.patch('pygitgo.commands.git_core.convert_https_to_ssh', return_value=url)
-    fake_success = mocker.patch('pygitgo.commands.git_core.success')
 
     branch = 'main'
     git_push(branch)
 
     fake_run.assert_any_call(
         ["git", "remote", "set-url", "origin", url], 
-        loading_msg="Converting remote from HTTPS to SSH for secure push..."
+        loading_msg="Converting remote from HTTPS to SSH for secure push...",
+        ok_text=f"Remote updated to: {url}"
     )
-
-    fake_success.assert_called()
 
     fake_run.assert_called_with(
         ["git", "push", "-u", "origin", branch], 
-        loading_msg=f"Pushing to remote branch '{branch}'..."
+        loading_msg=f"Pushing to remote branch '{branch}'...",
+        ok_text=None,
+        err_text="Push failed: verify your remote URL and SSH key, then try again."
     )
 
 def test_git_commit_skip_staging_does_not_run_git_add(mocker):

--- a/tests/test_git_core.py
+++ b/tests/test_git_core.py
@@ -7,10 +7,12 @@ import pytest
 
 def test_git_commit(mocker):
     mocker.patch("pygitgo.commands.git_core._get_signing_flags", return_value=[])
+    fake_sanitize = mocker.patch("pygitgo.commands.git_core.sanitize_signing_config")
     fake_run = mocker.patch("pygitgo.commands.git_core.run_command")
     
     result = git_commit("Testing the commit feature")
     assert result == True
+    fake_sanitize.assert_called_once()
 
     fake_run.assert_any_call(
         ['git', 'commit', '-S', '-m', 'Testing the commit feature'],
@@ -154,6 +156,7 @@ def test_git_push_convert_https_to_ssh(mocker):
 
 def test_git_commit_skip_staging_does_not_run_git_add(mocker):
     mocker.patch("pygitgo.commands.git_core._get_signing_flags", return_value=[])
+    mocker.patch("pygitgo.commands.git_core.sanitize_signing_config")
     fake_run = mocker.patch("pygitgo.commands.git_core.run_command")
     
     fake_run.side_effect = ["M file.py", None]
@@ -165,6 +168,7 @@ def test_git_commit_skip_staging_does_not_run_git_add(mocker):
 
 def test_git_commit_default_runs_git_add(mocker):
     mocker.patch("pygitgo.commands.git_core._get_signing_flags", return_value=[])
+    mocker.patch("pygitgo.commands.git_core.sanitize_signing_config")
     fake_run = mocker.patch("pygitgo.commands.git_core.run_command")
     fake_run.side_effect = ["M file.py", None, None]
     git_commit("my message")

--- a/tests/test_git_remote.py
+++ b/tests/test_git_remote.py
@@ -18,7 +18,8 @@ def test_confirm_remote_link_success(mocker):
 
     fake_run.assert_called_once_with(
         ["git", "ls-remote", "origin"], 
-        loading_msg="Testing connection to remote..."
+        loading_msg="Testing connection to remote...",
+        ok_text="Remote is reachable."
     )
 
 def test_confirm_remote_link_fallback(mocker):
@@ -33,7 +34,8 @@ def test_confirm_remote_link_fallback(mocker):
 
     fake_run.assert_called_once_with(
         ["git", "ls-remote", "origin"], 
-        loading_msg="Testing connection to remote..."
+        loading_msg="Testing connection to remote...",
+        ok_text="Remote is reachable."
     )
 
 def test_handle_rebase(mocker):
@@ -54,15 +56,14 @@ def test_add_remote_origin_switch_origin(mocker):
         return_value='https://github.com:Huerte/GitGo'
     )
     mocker.patch('pygitgo.commands.git_remote.isinstance', return_value=False)
-    fake_success = mocker.patch('pygitgo.commands.git_remote.success')
 
     url = ".com:Huerte/New-GitGo.git"
     add_remote_origin(url)
 
-    fake_success.assert_called_once_with(f"Remote origin set to: {url}")
     fake_run.assert_called_with(
         ["git", "remote", "set-url", "origin", url], 
-        loading_msg="Updating remote URL..."
+        loading_msg="Updating remote URL...",
+        ok_text=f"Remote origin set to: {url}"
     )
 
 def test_add_remote_origin_add_origin(mocker):
@@ -74,15 +75,14 @@ def test_add_remote_origin_add_origin(mocker):
             "added"
         ]
     )
-    fake_success = mocker.patch('pygitgo.commands.git_remote.success')
 
     url = ".com:Huerte/New-GitGo.git"
     add_remote_origin(url)
 
-    fake_success.assert_called_once_with(f"Remote origin set to: {url}")
     fake_run.assert_called_with(
         ["git", "remote", "add", "origin", url], 
-        loading_msg="Adding remote origin..."
+        loading_msg="Adding remote origin...",
+        ok_text=f"Remote origin set to: {url}"
     )
 
 def test_check_and_sync_branch_equal_branch(mocker):
@@ -94,12 +94,12 @@ def test_check_and_sync_branch_equal_branch(mocker):
         ]
     )
 
-    fake_success = mocker.patch('pygitgo.commands.git_remote.success')
+    fake_info = mocker.patch('pygitgo.commands.git_remote.info')
 
     branch = 'main'
     check_and_sync_branch(branch)
 
-    fake_success.assert_called_once_with("Branch is already up to date.")
+    fake_info.assert_called_once_with("Branch is already up to date.")
     
     assert fake_run.call_args_list == [
         call(["git", "fetch", "origin"], loading_msg="Checking if branch is up to date..."),
@@ -115,13 +115,12 @@ def test_check_and_sync_branch_remote_ahead(mocker):
         ]
     )
 
-    fake_success = mocker.patch('pygitgo.commands.git_remote.success')
+    fake_info = mocker.patch('pygitgo.commands.git_remote.info')
 
     branch = 'main'
-    remote_branch = 'master'
     check_and_sync_branch(branch)
 
-    fake_success.assert_called_once_with("Branch is up to date.")
+    fake_info.assert_called_once_with("Branch is up to date.")
     
     assert fake_run.call_args_list == [
         call(["git", "fetch", "origin"], loading_msg="Checking if branch is up to date..."),
@@ -138,19 +137,15 @@ def test_check_and_sync_branch_need_sync(mocker):
         ]
     )
 
-    fake_success = mocker.patch('pygitgo.commands.git_remote.success')
-
     branch = 'main'
     check_and_sync_branch(branch)
-
-    fake_success.assert_called_once_with("Synced with remote.")
     
     assert fake_run.call_args_list == [
         call(["git", "fetch", "origin"], loading_msg="Checking if branch is up to date..."),
         call(["git", "rev-parse", branch]),
         call(["git", "rev-parse", f"origin/{branch}"]),
         call(["git", "rev-list", "--count", f"{branch}..origin/{branch}"]),
-        call(["git", "pull", "--rebase", "origin", branch], loading_msg="Pulling changes from remote...")
+        call(["git", "pull", "--rebase", "origin", branch], loading_msg="Pulling changes from remote...", ok_text="Synced with remote.")
     ]
 
 def test_check_and_sync_branch_no_remote(mocker):

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -20,7 +20,8 @@ def test_undo_jump_operation_no_stash(mocker):
     )
     fake_run.assert_any_call(
         ['git', 'checkout', "original_branch"],
-        loading_msg="Jumping you back to the original branch 'original_branch'..."
+        loading_msg="Jumping you back to the original branch 'original_branch'...",
+        ok_text="Canceled safely. Back on 'original_branch'."
     )
     fake_pop.assert_not_called()
 
@@ -37,9 +38,10 @@ def test_undo_jump_operation_with_stash(mocker):
     )
     fake_run.assert_any_call(
         ['git', 'checkout', "original_branch"],
-        loading_msg="Jumping you back to the original branch 'original_branch'..."
+        loading_msg="Jumping you back to the original branch 'original_branch'...",
+        ok_text=None
     )
-    fake_pop.assert_called_once()
+    fake_pop.assert_called_once_with(ok_text="Canceled safely. Back on 'original_branch'. Your code is safe.")
 
 
 def test_undo_jump_operation_deletes_ghost_branch(mocker):
@@ -54,9 +56,10 @@ def test_undo_jump_operation_deletes_ghost_branch(mocker):
     )
     fake_run.assert_any_call(
         ["git", "branch", "-D", "ghost-branch"],
-        loading_msg="Removing the empty branch 'ghost-branch'..."
+        loading_msg="Removing the empty branch 'ghost-branch'...",
+        ok_text=None
     )
-    fake_pop.assert_called_once()
+    fake_pop.assert_called_once_with(ok_text="Canceled safely. Back on 'original_branch'. Your code is safe.")
 
 
 def test_jump_operation_same_branch(mocker):
@@ -97,12 +100,13 @@ def test_jump_operation_has_changes_moves_to_branch(mocker):
     fake_success = mocker.patch('pygitgo.commands.jump.success')
     mocker.patch('pygitgo.commands.jump.git_stash_push', return_value=True)
     mocker.patch('pygitgo.commands.jump.git_stash_apply', return_value=True)
-    mocker.patch('pygitgo.commands.jump.git_stash_drop', return_value=True)
+    fake_drop = mocker.patch('pygitgo.commands.jump.git_stash_drop', return_value=True)
     mocker.patch('pygitgo.commands.jump.run_command', side_effect=lambda *a, **kw: 'M file.txt' if a[0] == ['git', 'status', '--porcelain'] else 'ok')
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
     fake_info.assert_any_call("Changes saved. Jumping to the new branch...")
-    fake_success.assert_called_with("On 'feature'. Your changes came with you.")
+    fake_drop.assert_called_once_with(loading_msg="Cleaning up the temporary stash...", ok_text="On 'feature'. Your changes came with you.")
+    fake_success.assert_not_called()
 
 
 def test_jump_operation_no_changes(mocker):
@@ -114,7 +118,7 @@ def test_jump_operation_no_changes(mocker):
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
 
-    fake_success.assert_called_with("On 'feature'.")
+    fake_success.assert_not_called()
 
 
 
@@ -137,7 +141,6 @@ def test_jump_operation_branch_not_exist_cancel_operation(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=False)
-    # First input: "move changes?" yes, Second: "create branch?" no
     mocker.patch('builtins.input', side_effect=['y', 'n'])
 
     fake_info = mocker.patch('pygitgo.commands.jump.info')
@@ -149,15 +152,14 @@ def test_jump_operation_branch_not_exist_cancel_operation(mocker):
 
     fake_info.assert_any_call("Changes saved. Jumping to the new branch...")
     fake_info.assert_any_call("Exiting without jumping...")
-    fake_pop.assert_called_once()
+    fake_pop.assert_called_once_with(loading_msg="Putting your unsaved changes back...")
 
 
 def test_jump_operation_branch_not_exist_create_branch(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=False)
-    mocker.patch('pygitgo.commands.jump.git_new_branch', return_value=None)
-    # First input: "move changes?" yes, Second: "create branch?" yes
+    fake_new_branch = mocker.patch('pygitgo.commands.jump.git_new_branch', return_value=None)
     mocker.patch('builtins.input', side_effect=['y', 'y'])
 
     fake_success = mocker.patch('pygitgo.commands.jump.success')
@@ -174,9 +176,10 @@ def test_jump_operation_branch_not_exist_create_branch(mocker):
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
 
     fake_info.assert_any_call("Changes saved. Jumping to the new branch...")
-    fake_success.assert_any_call("On 'feature'. Your changes came with you.")
+    fake_new_branch.assert_called_once_with('feature', ok_text="Branch 'feature' created.")
+    fake_success.assert_not_called()
     fake_apply.assert_called_once()
-    fake_drop.assert_called_once()
+    fake_drop.assert_called_once_with(loading_msg="Cleaning up the temporary stash...", ok_text="On 'feature'. Your changes came with you.")
 
 
 def test_jump_operation_sync_fail_stay(mocker):
@@ -207,7 +210,6 @@ def test_jump_operation_merge_conflict_cancel(mocker):
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
     mocker.patch('pygitgo.commands.jump.undo_jump_operation', return_value=None)
-    # First: "move changes?" yes, Second: "fix conflict?" no
     mocker.patch('builtins.input', side_effect=['y', 'n'])
 
     fake_error = mocker.patch('pygitgo.commands.jump.error')
@@ -230,7 +232,6 @@ def test_jump_operation_merge_conflict_stay(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
-    # First: "move changes?" yes, Second: "fix conflict?" yes
     mocker.patch('builtins.input', side_effect=['y', 'y'])
 
     fake_success = mocker.patch('pygitgo.commands.jump.success')
@@ -254,4 +255,3 @@ def test_jump_operation_merge_conflict_stay(mocker):
     fake_warning.assert_any_call("Open your editor and fix the conflict lines.")
     fake_info.assert_any_call("Your stash backup is still saved. Run 'gitgo state list' to see it.")
     fake_drop.assert_not_called()
-

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -23,8 +23,8 @@ def test_link_existing_repo(mocker):
     link_operation(args)
 
     fake_add_remote.assert_called_once_with("git@github.com:user/repo.git")
-    fake_confirm.assert_called_once()
-    fake_success.assert_any_call("\nRemote linked to existing repository.")
+    fake_confirm.assert_called_once_with(ok_text="Remote linked to existing repository.")
+    fake_success.assert_not_called()
     fake_commit.assert_not_called()
 
 
@@ -43,7 +43,7 @@ def test_link_new_repo_no_remote_refs(mocker):
     args = Namespace(url="git@github.com:user/repo.git", message="Initial commit")
     link_operation(args)
 
-    fake_commit.assert_called_once_with("Initial commit", loading_msg="Creating initial commit...")
+    fake_commit.assert_called_once_with("Initial commit", loading_msg="Creating initial commit...", ok_text="Initial commit created.")
     fake_add_remote.assert_called_once_with("git@github.com:user/repo.git")
     fake_run.assert_any_call(["git", "branch", "-m", "main"], loading_msg="Renaming branch 'master' to 'main'...")
     fake_run.assert_any_call(["git", "ls-remote", "--heads", "origin", "main"], loading_msg="Checking remote branches...")
@@ -74,9 +74,10 @@ def test_link_new_repo_with_remote_refs_pull_success(mocker):
 
     fake_run.assert_any_call(
         ["git", "pull", "origin", "main", "--allow-unrelated-histories", "--no-edit"],
-        loading_msg="Pulling and merging remote content..."
+        loading_msg="Pulling and merging remote content...",
+        ok_text="Remote content merged."
     )
-    fake_success.assert_any_call("Remote content merged.")
+    fake_success.assert_not_called()
     fake_push.assert_called_once_with("main")
 
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,29 +1,60 @@
 from pygitgo.auth.manager import login, logout
 from pathlib import Path
+import pytest
 
 
-def test_login_already_logged_in(mocker):
+def test_login_already_logged_in_with_managed_key(mocker):
+    mocker.patch("pygitgo.auth.account.sanitize_signing_config")
     fake_check = mocker.patch("pygitgo.auth.manager.ssh_utils.check_connection", return_value=True)
+    
+    mock_key = mocker.MagicMock(spec=Path)
+    mock_key.exists.return_value = True
+    mocker.patch("pygitgo.auth.manager.ssh_utils.get_ssh_key_path", return_value=mock_key)
+    
+    fake_config_signing = mocker.patch("pygitgo.auth.manager._configure_ssh_signing")
+    fake_ensure = mocker.patch("pygitgo.auth.account.ensure_user_configure")
+    mocker.patch("pygitgo.auth.manager.ssh_utils.get_github_username", return_value="GithubUser")
     fake_success = mocker.patch("pygitgo.auth.manager.success")
-    mocker.patch("pygitgo.auth.manager.open_url")
 
     result = login()
 
     assert result is True
     fake_check.assert_called_once()
-    fake_success.assert_called_once_with("You are already logged in!")
+    fake_config_signing.assert_called_once_with(mock_key)
+    fake_ensure.assert_called_once_with(default_username="GithubUser")
+    fake_success.assert_called_once_with("You are already logged in via GitGo.")
+
+
+def test_login_already_logged_in_with_unmanaged_key(mocker):
+    mocker.patch("pygitgo.auth.account.sanitize_signing_config")
+    fake_check = mocker.patch("pygitgo.auth.manager.ssh_utils.check_connection", return_value=True)
+    
+    mock_key = mocker.MagicMock(spec=Path)
+    mock_key.exists.return_value = False
+    mocker.patch("pygitgo.auth.manager.ssh_utils.get_ssh_key_path", return_value=mock_key)
+    
+    fake_warning = mocker.patch("pygitgo.auth.manager.warning")
+    fake_info = mocker.patch("pygitgo.auth.manager.info")
+
+    result = login()
+
+    assert result is True
+    fake_check.assert_called_once()
+    assert fake_warning.call_count == 2
+    assert fake_info.call_count == 2
 
 
 def test_login_new_user_success(mocker):
-    # check_connection returns False first, then True on verification
+    mocker.patch("pygitgo.auth.account.sanitize_signing_config")
     fake_check = mocker.patch("pygitgo.auth.manager.ssh_utils.check_connection", side_effect=[False, True])
     mocker.patch("pygitgo.auth.manager.info")
     mocker.patch("pygitgo.auth.manager.open_url")
     mocker.patch("pygitgo.auth.manager.success")
-    mocker.patch("builtins.input", side_effect=["test@example.com", ""])
+    mocker.patch("builtins.input", side_effect=["test@example.com", "", ""])
     mocker.patch("pygitgo.auth.manager.ssh_utils.generate_ssh_key", return_value=Path("mock_key"))
+    mocker.patch("pygitgo.auth.manager.ssh_utils.get_ssh_key_path", return_value=Path("mock_key"))
+    mocker.patch("pygitgo.auth.manager.ssh_utils.ensure_ssh_agent")
     
-    # Mock reading public key
     mocker.patch("builtins.open", mocker.mock_open(read_data="ssh-rsa AAAAB3NzaC1yc2E..."))
     mocker.patch("pygitgo.auth.manager.ssh_utils.get_github_username", return_value="GithubUser")
     fake_ensure = mocker.patch("pygitgo.auth.account.ensure_user_configure", return_value=True)
@@ -35,15 +66,39 @@ def test_login_new_user_success(mocker):
 
 
 def test_login_new_user_verification_fails(mocker):
+    mocker.patch("pygitgo.auth.account.sanitize_signing_config")
     fake_check = mocker.patch("pygitgo.auth.manager.ssh_utils.check_connection", return_value=False)
     mocker.patch("pygitgo.auth.manager.info")
     mocker.patch("pygitgo.auth.manager.success")
     mocker.patch("pygitgo.auth.manager.error")
-    mocker.patch("builtins.input", side_effect=["test@example.com", ""])
+    mocker.patch("builtins.input", side_effect=["test@example.com", "", ""])
     mocker.patch("pygitgo.auth.manager.ssh_utils.generate_ssh_key", return_value=Path("mock_key"))
+    mocker.patch("pygitgo.auth.manager.ssh_utils.get_ssh_key_path", return_value=Path("mock_key"))
+    mocker.patch("pygitgo.auth.manager.ssh_utils.ensure_ssh_agent")
     mocker.patch("pygitgo.auth.manager.open_url")
     mocker.patch("builtins.open", mocker.mock_open(read_data="ssh-rsa AAAAB3NzaC1yc2E..."))
+    
+    mocker.patch("pygitgo.auth.manager.get_platform", return_value="windows")
 
+    result = login()
+
+    assert result is False
+
+
+def test_login_new_user_verification_fails_linux(mocker):
+    mocker.patch("pygitgo.auth.account.sanitize_signing_config")
+    fake_check = mocker.patch("pygitgo.auth.manager.ssh_utils.check_connection", return_value=False)
+    mocker.patch("pygitgo.auth.manager.info")
+    mocker.patch("pygitgo.auth.manager.success")
+    mocker.patch("pygitgo.auth.manager.error")
+    mocker.patch("builtins.input", side_effect=["test@example.com", "", ""])
+    mocker.patch("pygitgo.auth.manager.ssh_utils.generate_ssh_key", return_value=Path("mock_key"))
+    mocker.patch("pygitgo.auth.manager.ssh_utils.get_ssh_key_path", return_value=Path("mock_key"))
+    mocker.patch("pygitgo.auth.manager.ssh_utils.ensure_ssh_agent")
+    mocker.patch("pygitgo.auth.manager.open_url")
+    mocker.patch("builtins.open", mocker.mock_open(read_data="ssh-rsa AAAAB3NzaC1yc2E..."))
+    
+    mocker.patch("pygitgo.auth.manager.get_platform", return_value="linux")
 
     result = login()
 
@@ -52,7 +107,6 @@ def test_login_new_user_verification_fails(mocker):
 
 def test_logout_not_logged_in(mocker):
     mocker.patch("pygitgo.auth.manager.ssh_utils.get_ssh_key_path", return_value=Path("non_existent_key"))
-    # mock exists() to return False
     mocker.patch.object(Path, "exists", return_value=False)
     fake_warning = mocker.patch("pygitgo.auth.manager.warning")
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,5 +1,6 @@
 from pygitgo.auth.manager import login, logout
 from pathlib import Path
+from unittest.mock import call
 import pytest
 
 
@@ -19,10 +20,10 @@ def test_login_already_logged_in_with_managed_key(mocker):
     result = login()
 
     assert result is True
-    fake_check.assert_called_once()
+    fake_check.assert_called_once_with(ok_text="Already logged in via GitGo.")
     fake_config_signing.assert_called_once_with(mock_key)
     fake_ensure.assert_called_once_with(default_username="GithubUser")
-    fake_success.assert_called_once_with("You are already logged in via GitGo.")
+    fake_success.assert_not_called()
 
 
 def test_login_already_logged_in_with_unmanaged_key(mocker):
@@ -39,7 +40,7 @@ def test_login_already_logged_in_with_unmanaged_key(mocker):
     result = login()
 
     assert result is True
-    fake_check.assert_called_once()
+    fake_check.assert_called_once_with(ok_text="GitHub connection verified.")
     assert fake_warning.call_count == 2
     assert fake_info.call_count == 2
 
@@ -63,6 +64,10 @@ def test_login_new_user_success(mocker):
 
     assert result is True
     fake_ensure.assert_called_once_with(default_email="test@example.com", default_username="GithubUser")
+    fake_check.assert_has_calls([
+        call(ok_text="GitHub connection verified."),
+        call(ok_text="Login successful. You are connected.", fail_text="SSH key not recognised by GitHub.")
+    ])
 
 
 def test_login_new_user_verification_fails(mocker):
@@ -83,6 +88,10 @@ def test_login_new_user_verification_fails(mocker):
     result = login()
 
     assert result is False
+    fake_check.assert_has_calls([
+        call(ok_text="GitHub connection verified."),
+        call(ok_text="Login successful. You are connected.", fail_text="SSH key not recognised by GitHub.")
+    ])
 
 
 def test_login_new_user_verification_fails_linux(mocker):
@@ -103,6 +112,10 @@ def test_login_new_user_verification_fails_linux(mocker):
     result = login()
 
     assert result is False
+    fake_check.assert_has_calls([
+        call(ok_text="GitHub connection verified."),
+        call(ok_text="Login successful. You are connected.", fail_text="SSH key not recognised by GitHub.")
+    ])
 
 
 def test_logout_not_logged_in(mocker):

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -21,9 +21,10 @@ def test_pull_operation_success_no_branch(mock_get_branch, mock_success, mock_ru
     mock_run_command.assert_any_call(["git", "ls-remote", "--heads", "origin", "main"])
     mock_run_command.assert_any_call(
         ["git", "pull", "--rebase", "--autostash", "origin", "main"], 
-        loading_msg="Downloading latest updates for 'main' (auto-saving your code)..."
+        loading_msg="Downloading latest updates for 'main' (auto-saving your code)...",
+        ok_text="Project is up to date with 'main'."
     )
-    mock_success.assert_called_once()
+    mock_success.assert_not_called()
 
 @patch("pygitgo.commands.pull.run_command")
 @patch("pygitgo.commands.pull.success")
@@ -40,9 +41,10 @@ def test_pull_operation_success_with_branch(mock_success, mock_run_command):
     mock_run_command.assert_any_call(["git", "ls-remote", "--heads", "origin", "feature/test"])
     mock_run_command.assert_any_call(
         ["git", "pull", "--rebase", "--autostash", "origin", "feature/test"], 
-        loading_msg="Downloading latest updates for 'feature/test' (auto-saving your code)..."
+        loading_msg="Downloading latest updates for 'feature/test' (auto-saving your code)...",
+        ok_text="Project is up to date with 'feature/test'."
     )
-    mock_success.assert_called_once()
+    mock_success.assert_not_called()
 
 @patch("pygitgo.commands.pull.run_command")
 def test_pull_operation_branch_not_found(mock_run_command):
@@ -93,10 +95,10 @@ def test_pull_keyboard_interrupt_rebase_in_progress(mock_path, mock_warning, moc
         pull_operation(args)
 
     assert sys_exit.value.code == 130
-    mock_run_command.assert_any_call(["git", "rebase", "--abort"], loading_msg="Aborting interrupted rebase...")
+    mock_run_command.assert_any_call(["git", "rebase", "--abort"], loading_msg="Aborting interrupted rebase...", ok_text="Rebase aborted. Branch is back to its pre-pull state.")
     mock_warning.assert_any_call("Pull interrupted (Ctrl+C).")
     mock_warning.assert_any_call("A rebase is in progress from the interrupted pull.")
-    mock_success.assert_called_with("Rebase aborted. Branch is back to its pre-pull state.")
+    mock_success.assert_not_called()
 
 
 @patch("pygitgo.commands.pull.run_command")
@@ -126,4 +128,3 @@ def test_pull_keyboard_interrupt_no_rebase(mock_path, mock_warning, mock_success
     for call in mock_run_command.call_args_list:
         assert "--abort" not in call[0][0]
     mock_success.assert_called_with("No partial rebase detected. Branch is clean.")
-

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -160,8 +160,7 @@ def test_push_keyboard_interrupt_commit_made(mocker):
     mocker.patch("pygitgo.commands.push.git_push", side_effect=KeyboardInterrupt)
     
     fake_run = mocker.patch("pygitgo.commands.push.run_command")
-    fake_run.side_effect = ["old_hash", "new_hash"] # first call: initial rev-parse HEAD. second call: post-cleanup check.
-    
+    fake_run.side_effect = ["old_hash", "new_hash"]
     fake_warning = mocker.patch("pygitgo.commands.push.warning")
     fake_info = mocker.patch("pygitgo.commands.push.info")
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -70,7 +70,6 @@ def test_create_github_repo_success(mock_urlopen):
 @patch("pygitgo.commands.repo._prompt_for_token", return_value="new-token")
 @patch("pygitgo.commands.repo._clear_saved_token")
 def test_create_github_repo_401_retry(mock_clear, mock_prompt, mock_token, mock_urlopen):
-    # First call fails with 401, second call (during retry) succeeds
     mock_error_resp = MagicMock()
     mock_error_resp.code = 401
     mock_error_resp.read.return_value = b'{"message": "Unauthorized"}'
@@ -79,7 +78,6 @@ def test_create_github_repo_401_retry(mock_clear, mock_prompt, mock_token, mock_
     mock_success_resp.read.return_value = b'{"clone_url": "https://github.com/user/repo-retry.git"}'
     mock_success_resp.__enter__.return_value = mock_success_resp
 
-    # We mock urlopen to raise HTTPError first, then return success response
     mock_urlopen.side_effect = [
         urllib.error.HTTPError("url", 401, "msg", {}, mock_error_resp),
         mock_success_resp

--- a/tests/test_ssh_utils.py
+++ b/tests/test_ssh_utils.py
@@ -1,6 +1,7 @@
 from pygitgo.auth.ssh_utils import (
     ensure_github_known_host, check_connection, get_github_username,
-    generate_ssh_key, convert_https_to_ssh, is_ssh_url
+    generate_ssh_key, convert_https_to_ssh, is_ssh_url,
+    _try_ssh_add, ensure_ssh_agent, clear_ssh_cache
 )
 from pygitgo.exceptions import GitGoError
 from pathlib import Path
@@ -39,16 +40,26 @@ def test_check_connection_success(mocker):
     mocker.patch("pygitgo.auth.ssh_utils.ensure_github_known_host")
     mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Hi user! You've successfully authenticated.")
 
+    mock_spinner = mocker.MagicMock()
+    mocker.patch("yaspin.yaspin", return_value=mock_spinner)
+
     result = check_connection()
     assert result is True
+    mock_spinner.start.assert_called_once()
+    mock_spinner.ok.assert_called_once_with("✔")
 
 
 def test_check_connection_failure(mocker):
     mocker.patch("pygitgo.auth.ssh_utils.ensure_github_known_host")
     mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Permission denied.")
 
+    mock_spinner = mocker.MagicMock()
+    mocker.patch("yaspin.yaspin", return_value=mock_spinner)
+
     result = check_connection()
     assert result is False
+    mock_spinner.start.assert_called_once()
+    mock_spinner.fail.assert_called_once_with("✖")
 
 
 def test_get_github_username_success(mocker):
@@ -116,4 +127,61 @@ def test_is_ssh_url_valid(url):
 def test_is_ssh_url_invalid(url):
     result = is_ssh_url(url)
     assert result is False
+
+
+def test_try_ssh_add_success(mocker):
+    fake_run = mocker.patch("pygitgo.auth.ssh_utils.run_command", return_value="added")
+    assert _try_ssh_add(Path("mock_key")) is True
+    fake_run.assert_called_once_with(["ssh-add", "mock_key"])
+
+
+def test_try_ssh_add_failure(mocker):
+    from pygitgo.exceptions import GitCommandError
+    fake_run = mocker.patch("pygitgo.auth.ssh_utils.run_command", side_effect=GitCommandError(["ssh-add"]))
+    assert _try_ssh_add(Path("mock_key")) is False
+
+
+def test_ensure_ssh_agent_success_immediately(mocker):
+    fake_try = mocker.patch("pygitgo.auth.ssh_utils._try_ssh_add", return_value=True)
+    assert ensure_ssh_agent(Path("mock_key")) is True
+    fake_try.assert_called_once_with(Path("mock_key"))
+
+
+def test_ensure_ssh_agent_windows_success_after_start(mocker):
+    fake_try = mocker.patch("pygitgo.auth.ssh_utils._try_ssh_add", side_effect=[False, True])
+    mocker.patch("pygitgo.auth.ssh_utils.get_platform", return_value="windows")
+    fake_sub = mocker.patch("subprocess.run")
+    mocker.patch("time.sleep")
+
+    assert ensure_ssh_agent(Path("mock_key")) is True
+    assert fake_try.call_count == 2
+    fake_sub.assert_called_once_with(["sc", "start", "ssh-agent"], capture_output=True, timeout=5)
+
+
+def test_ensure_ssh_agent_windows_failure(mocker):
+    fake_try = mocker.patch("pygitgo.auth.ssh_utils._try_ssh_add", return_value=False)
+    mocker.patch("pygitgo.auth.ssh_utils.get_platform", return_value="windows")
+    fake_sub = mocker.patch("subprocess.run")
+    mocker.patch("time.sleep")
+    fake_warning = mocker.patch("pygitgo.auth.ssh_utils.warning")
+    fake_info = mocker.patch("pygitgo.auth.ssh_utils.info")
+
+    assert ensure_ssh_agent(Path("mock_key")) is False
+    assert fake_try.call_count == 2
+    fake_sub.assert_called_once_with(["sc", "start", "ssh-agent"], capture_output=True, timeout=5)
+    assert fake_warning.call_count == 1
+    assert fake_info.call_count == 4
+
+
+def test_ensure_ssh_agent_linux_failure(mocker):
+    fake_try = mocker.patch("pygitgo.auth.ssh_utils._try_ssh_add", return_value=False)
+    mocker.patch("pygitgo.auth.ssh_utils.get_platform", return_value="linux")
+    fake_warning = mocker.patch("pygitgo.auth.ssh_utils.warning")
+    fake_info = mocker.patch("pygitgo.auth.ssh_utils.info")
+
+    assert ensure_ssh_agent(Path("mock_key")) is False
+    fake_try.assert_called_once_with(Path("mock_key"))
+    assert fake_warning.call_count == 1
+    assert fake_info.call_count == 2
+
 

--- a/tests/test_ssh_utils.py
+++ b/tests/test_ssh_utils.py
@@ -23,7 +23,6 @@ def test_ensure_github_known_host_not_exists(mocker):
     mocker.patch("pathlib.Path.mkdir")
     mock_file = mocker.patch("builtins.open", mocker.mock_open())
     
-    # Mock return value of run_command as a completed process
     mock_process = mocker.MagicMock()
     mock_process.stdout = "github.com ssh-rsa AAA...\n"
     fake_run = mocker.patch("pygitgo.auth.ssh_utils.run_command", return_value=mock_process)

--- a/tests/test_stash.py
+++ b/tests/test_stash.py
@@ -12,7 +12,8 @@ def test_git_stash_push_success(mocker):
     assert result is True
     fake_run.assert_called_once_with(
         ["git", "stash", "push", "-u", "-m", "GitGo Auto-Stash"],
-        loading_msg="Saving your changes..."
+        loading_msg="Saving your changes...",
+        ok_text=None
     )
 
 
@@ -37,7 +38,8 @@ def test_git_stash_pop_success(mocker):
     assert result is True
     fake_run.assert_called_once_with(
         ["git", "stash", "pop"],
-        loading_msg="Restoring your saved changes..."
+        loading_msg="Restoring your saved changes...",
+        ok_text=None
     )
 
 
@@ -56,7 +58,8 @@ def test_git_stash_apply_success_no_id(mocker):
     assert result is True
     fake_run.assert_called_once_with(
         ["git", "stash", "apply"],
-        loading_msg="Applying saved changes..."
+        loading_msg="Applying saved changes...",
+        ok_text=None
     )
 
 
@@ -66,7 +69,8 @@ def test_git_stash_apply_success_with_id(mocker):
     assert result is True
     fake_run.assert_called_once_with(
         ["git", "stash", "apply", "stash@{2}"],
-        loading_msg="Applying saved changes..."
+        loading_msg="Applying saved changes...",
+        ok_text=None
     )
 
 
@@ -85,7 +89,8 @@ def test_git_stash_drop_success_no_id(mocker):
     assert result is True
     fake_run.assert_called_once_with(
         ["git", "stash", "drop"],
-        loading_msg="Cleaning up stash..."
+        loading_msg="Cleaning up stash...",
+        ok_text=None
     )
 
 
@@ -95,7 +100,8 @@ def test_git_stash_drop_success_with_id(mocker):
     assert result is True
     fake_run.assert_called_once_with(
         ["git", "stash", "drop", "stash@{1}"],
-        loading_msg="Cleaning up stash..."
+        loading_msg="Cleaning up stash...",
+        ok_text=None
     )
 
 
@@ -119,7 +125,8 @@ def test_git_stash_list_success(mocker):
             "--date=format:%Y-%m-%d %H:%M:%S",
             "--pretty=%gd||%cd||%s"
         ],
-        loading_msg="Fetching stash list..."
+        loading_msg="Fetching stash list...",
+        ok_text=None
     )
 
 
@@ -138,7 +145,8 @@ def test_git_stash_clear_success(mocker):
     assert result is True
     fake_run.assert_called_once_with(
         ["git", "stash", "clear"],
-        loading_msg="Clearing all stashes..."
+        loading_msg="Clearing all stashes...",
+        ok_text=None
     )
 
 

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -45,8 +45,8 @@ def test_undo_changes_success(mock_input, mock_success, mock_run_command):
     mock_input.assert_called_once()
     assert mock_run_command.call_count == 2
     mock_run_command.assert_any_call(["git", "reset", "--hard", "HEAD"], loading_msg="Throwing away edits...")
-    mock_run_command.assert_any_call(["git", "clean", "-fd"], loading_msg="Removing new files...")
-    mock_success.assert_called_once()
+    mock_run_command.assert_any_call(["git", "clean", "-fd"], loading_msg="Removing new files...", ok_text="Working tree reset. All changes discarded.")
+    mock_success.assert_not_called()
 
 
 @patch("pygitgo.commands.undo.run_command")
@@ -59,7 +59,6 @@ def test_undo_changes_abort(mock_input, mock_info, mock_run_command):
     mock_run_command.assert_not_called()
 
 
-# --- undo_link tests ---
 
 @patch("pygitgo.commands.undo.run_command")
 @patch("pygitgo.commands.undo.success")
@@ -81,14 +80,12 @@ def test_undo_link_no_remote(mock_run_command):
 @patch("pygitgo.commands.undo.success")
 @patch("pygitgo.commands.undo.info")
 def test_undo_link_no_commit_to_reset(mock_info, mock_success, mock_run_command):
-    # First call (remote remove) succeeds, second (reset) fails.
     mock_run_command.side_effect = [None, GitCommandError(["git", "reset"])]
     undo_link()
     mock_success.assert_called_once_with("Remote 'origin' removed.")
     assert mock_info.call_count == 2
 
 
-# --- undo_push tests ---
 
 @patch("pygitgo.commands.undo.run_command")
 @patch("pygitgo.commands.undo.get_current_branch", return_value="main")
@@ -97,8 +94,8 @@ def test_undo_link_no_commit_to_reset(mock_info, mock_success, mock_run_command)
 def test_undo_push_success(mock_input, mock_success, mock_branch, mock_run_command):
     undo_push()
     mock_run_command.assert_any_call(["git", "reset", "--soft", "HEAD~"], loading_msg="Reverting last commit locally...")
-    mock_run_command.assert_any_call(["git", "push", "--force", "origin", "main"], loading_msg="Force-pushing reverted state to 'main'...")
-    mock_success.assert_called_once()
+    mock_run_command.assert_any_call(["git", "push", "--force", "origin", "main"], loading_msg="Force-pushing reverted state to 'main'...", ok_text="Last push reverted. Remote 'main' is back to the previous commit.")
+    mock_success.assert_not_called()
 
 
 @patch("pygitgo.commands.undo.run_command")
@@ -128,8 +125,6 @@ def test_undo_push_force_push_fails(mock_input, mock_branch, mock_run_command):
     with pytest.raises(GitGoError, match="Force-push failed"):
         undo_push()
 
-
-# --- undo_operation routing tests ---
 
 @patch("pygitgo.commands.undo.undo_commit")
 def test_undo_operation_commit(mock_undo_commit):


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / internal

## Changes

- `executor.py`, `repo.py`, `init.py`, `ssh_utils.py`: spinner now prints both success and error text inline instead of calling separate `success()` or `error()` methods after.
- `ssh_utils.py`: spinner is shown during GitHub connection check so the terminal no longer freezes silently for 4-10 seconds on login.
- `ssh_utils.py`: SSH handshake result is now cached so it doesn't run twice during the same login session
- `manager.py`: removed redundant startup network check and cleaned up old commented-out code.
- `.github/PULL_REQUEST_TEMPLATE.md`: removed Overview and How to Test sections. Kept Type, Changes, and Checklist.

## Checklist

- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md)
- [ ] `README.md` updated (if a command was added or changed)
- [x] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)