### PR TITLE
chore: centralize cli output, harden error paths, expand test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,25 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Nested Folder Guard:** Added a directory validation check to `gitgo new` that aborts the operation if you are already inside a folder with the same name, preventing accidental nested projects.
+- **SSH Key Guard:** Added an overwrite confirmation prompt during `gitgo user login` if an existing SSH key is detected.
+- **Orphan Repo Recovery:** `gitgo new` can delete the GitHub repo it just created if linking fails, so you're not left with a remote you didn't mean to keep.
+
+### Changed
+- **UI Architecture:** Centralized all terminal output logic into `pygitgo.utils.cli_io`. Removed old print wrappers from `colors.py`, which now strictly handles ANSI constants.
+- **Prompts:** Replaced raw `input()` calls across the codebase with a unified `cli_io.confirm()` helper for consistent yes/no gating.
+- **Copywriting:** Updated prompt text to be friendlier for beginners (e.g., "unsaved changes" is now "unsaved edits", and error messages use calmer punctuation). Fixed typo "Commiting" to "Committing".
+- **Success States:** Added prominent `banner()` printouts for successful completion of major workflows like `pull`, `jump`, `undo`, `init`, and `repo`.
+- **Undo Refactor:** Re-architected `undo.py` to return success flags so it prints exactly one success banner at the very end, preventing duplicate output spam.
+- **Error Handling:** Shifted manual `error()` print statements to raised `GitGoError` exceptions in `config.py` and `link.py` for better error propagation.
+- **Authentication Retry:** Added an automatic 3-retry limit for invalid tokens in `gitgo repo` before hard-failing.
+- **`gitgo init`:** Standalone init now points to `gitgo repo` and `gitgo link` instead of suggesting `gitgo new` again.
+
 ### Fixed
+- Fixed `gitgo new` showing a success banner when linking failed. Failures now exit with an error and skip the banner.
+- Fixed `confirm_remote_link` failing silently on existing repos. Connection errors now raise `GitGoError`.
+- Fixed `gitgo push` auto-switching branches without asking. It now confirms before calling `jump`.
 - Fixed visual freezes by adding loading spinners to the network check in `gitgo pull` and local reset actions in `gitgo undo` commands.
 - Fixed the login flow UX by making the background `ssh-agent` check silent during key generation, preventing disjointed warning messages.
 - Fixed the fallback manual browser URL in the login flow printing unconditionally even when the browser opens successfully.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,8 @@ pytest tests/ --cov=pygitgo --cov-report=term-missing
 
 Tests use `pytest` and `pytest-mock`. No real Git repos are created during tests. Mock `subprocess.run` and `run_command` where needed.
 
+Note: The codebase now includes tests for the CLI helpers (`tests/test_cli_io.py`) and relies on additional dev dependencies such as `yaspin` and `pick`. Ensure these are installed in your development environment (see `pyproject.toml`).
+
 ### Writing Tests
 
 - Place new test files in `tests/` named `test_<module>.py`.
@@ -165,8 +167,17 @@ git commit -m "update"
 ### Error Handling
 
 - Raise `GitGoError` subclasses (`GitCommandError`) instead of calling `sys.exit()` inside command modules.
-- Only `main.py` should call `sys.exit()`. Command functions should raise or return.
+- Only `main.py` should call `sys.exit()`. Command functions should raise errors and may return a boolean success flag (`True`/`False`) to indicate operation outcome.
+- Prefer raising a `GitGoError` for recoverable/user-facing failures instead of printing and returning silently.
 - Never swallow exceptions silently with empty `except` blocks.
+
+### CLI output & UX
+
+- Centralize interactive and formatted CLI output through `pygitgo.utils.cli_io`.
+- Use the helpers: `info`, `warning`, `error`, `success`, `confirm`, `danger`, and `banner` for consistent prompts and messaging.
+- Avoid using `pygitgo.utils.colors` as print wrappers; `colors.py` now only exposes ANSI constants.
+- Use `confirm(..., destructive=True)` for irreversible actions so prompts clearly indicate risk.
+- Command implementations should avoid raw `input()` or ad-hoc `print()`; prefer the `cli_io` helpers for testability.
 
 ---
 

--- a/src/pygitgo/auth/account.py
+++ b/src/pygitgo/auth/account.py
@@ -1,6 +1,7 @@
-from pygitgo.utils.colors import info, success, warning, error, BLUE, RESET
+from pygitgo.utils.cli_io import info, success, warning, error
 from pygitgo.utils.executor import run_command
 from pygitgo.exceptions import GitCommandError
+from pygitgo.utils.colors import BLUE, RESET
 
 
 def get_user():
@@ -24,7 +25,7 @@ def get_user():
 def set_user(name, email):
     run_command(["git", "config", "--global", "user.name", name])
     run_command(["git", "config", "--global", "user.email", email])
-    success(f"\nGit user configured Successfully")
+    success("\nGit user configured successfully.")
     print(f"{BLUE}Username{RESET} : {name}")
     print(f"{BLUE}Email    {RESET}: {email}")
 

--- a/src/pygitgo/auth/manager.py
+++ b/src/pygitgo/auth/manager.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.colors import info, success, warning, error
+from pygitgo.utils.cli_io import info, success, warning, error
 from pygitgo.utils.platform import get_platform
 from pygitgo.utils.executor import run_command
 from pygitgo.exceptions import GitCommandError
@@ -124,7 +124,7 @@ def logout():
         except GitCommandError:
             pass
 
-        success("User successfully logout")
+        success("User successfully logged out.")
         return True
     
     except Exception as e:

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -1,5 +1,5 @@
 from pygitgo.exceptions import GitCommandError, GitGoError
-from pygitgo.utils.colors import info, success, warning
+from pygitgo.utils.cli_io import info, success, warning
 from pygitgo.utils.platform import get_platform
 from pygitgo.utils.executor import run_command
 from pathlib import Path
@@ -115,6 +115,9 @@ def generate_ssh_key(email):
         key_path.parent.mkdir(parents=True)
     
     if key_path.exists():
+        from pygitgo.utils.cli_io import confirm
+        if not confirm(f"SSH key {key_path} already exists. Overwrite it? (y/n): ", destructive=True):
+            raise GitGoError("SSH key generation aborted. Please back up your existing key or configure it manually.")
         os.remove(key_path)
     if (key_path.parent / f"{key_path.name}.pub").exists():
         os.remove(key_path.parent / f"{key_path.name}.pub")

--- a/src/pygitgo/commands/config.py
+++ b/src/pygitgo/commands/config.py
@@ -1,5 +1,6 @@
 from pygitgo.utils.config import get_config, set_config
-from pygitgo.utils.colors import error, warning, info
+from pygitgo.utils.cli_io import warning, info
+from pygitgo.exceptions import GitGoError
 
 
 def config_operation(args):
@@ -10,14 +11,11 @@ def config_operation(args):
 
     VALID_KEYS = ["default-branch", "default-message"]
     if key not in VALID_KEYS:
-        error(f"\nInvalid configuration key: '{key}'")
-        warning(f"Valid keys are: {', '.join(VALID_KEYS)}\n")
-        return
+        raise GitGoError(f"Invalid configuration key: '{key}'. Valid keys are: {', '.join(VALID_KEYS)}")
 
     if action == 'set':
         if not value:
-            error("\nYou must provide a value to set!\n")
-            return
+            raise GitGoError("You must provide a value to set!")
         set_config(key, value)
     elif action == 'get':
         current_value = get_config(key, None)

--- a/src/pygitgo/commands/git_branch.py
+++ b/src/pygitgo/commands/git_branch.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.colors import success, error, info
+from pygitgo.utils.cli_io import success, error, info, confirm
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
 from pygitgo.utils.config import get_config
@@ -44,9 +44,8 @@ def git_new_branch(branch, ok_text=None):
         if current == branch:
             info(f"Already on branch '{branch}'. Continuing...")
         else:
-            error(f"Failed to create branch '{branch}'! It may already exist.")
-            choice = input("\nWould you like to jump to the existing branch instead? (y/n): ").strip().lower()
-            if choice == "y":
+            error(f"Failed to create branch '{branch}'. It may already exist.")
+            if confirm(f"Switch to the existing branch '{branch}' instead? (y/n): "):
                 from pygitgo.commands.jump import jump_operation
                 jump_operation(Namespace(branch=branch))
             else:

--- a/src/pygitgo/commands/git_core.py
+++ b/src/pygitgo/commands/git_core.py
@@ -1,10 +1,10 @@
 from pygitgo.auth.ssh_utils import convert_https_to_ssh, get_ssh_key_path, is_ssh_url, check_connection
-from pygitgo.utils.colors import info, success, warning, error
 from pygitgo.exceptions import GitGoError, GitCommandError
 from pygitgo.auth.account import sanitize_signing_config
 from pygitgo.commands.git_remote import handle_rebase
 from pygitgo.utils.config import get_default_branch
 from pygitgo.utils.executor import run_command
+from pygitgo.utils.cli_io import info, warning
 import os
 
 
@@ -19,7 +19,7 @@ def _get_signing_flags():
     ]
 
 
-def git_commit(commit_message, loading_msg="Commiting changes...", skip_staging=False, ok_text=None):
+def git_commit(commit_message, loading_msg="Committing changes...", skip_staging=False, ok_text=None):
     if not ok_text:
         ok_text = "Changes committed."
     try:

--- a/src/pygitgo/commands/git_remote.py
+++ b/src/pygitgo/commands/git_remote.py
@@ -1,5 +1,5 @@
-from pygitgo.utils.colors import info, success, warning, error
 from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.utils.cli_io import info, warning, error
 from pygitgo.utils.executor import run_command
 
 
@@ -15,18 +15,14 @@ def add_remote_origin(repo_url):
 
 
 def confirm_remote_link(ok_text=None):
+    if not ok_text:
+        ok_text = "Remote is reachable."
     try:
-        if not ok_text:
-            ok_text = "Remote is reachable."
         run_command(["git", "ls-remote", "origin"], loading_msg="Testing connection to remote...", ok_text=ok_text)
         return True
     except GitCommandError:
-        error("Connection failed — verify the URL and your SSH key.")
         info("Run:  git remote -v   to inspect your current remote.")
-        return False
-
-
-
+        raise GitGoError("Connection failed — verify the URL and your SSH key.")
 
 
 def check_and_sync_branch(branch):

--- a/src/pygitgo/commands/init.py
+++ b/src/pygitgo/commands/init.py
@@ -1,6 +1,6 @@
 from pygitgo.commands.git_core import git_init
-from pygitgo.utils.colors import info, success
 from pygitgo.exceptions import GitGoError
+from pygitgo.utils.cli_io import info
 import urllib.request
 import urllib.error
 import zipfile
@@ -292,7 +292,7 @@ def _scaffold_language(lang, target_dir, name):
         info(f"Created {name}.csproj and Program.cs")
 
 
-def init_operation(args):
+def init_operation(args, standalone=False):
     target_dir = args.name
 
     if os.path.exists(target_dir) and os.listdir(target_dir):
@@ -311,7 +311,10 @@ def init_operation(args):
         os.chdir(target_dir)
         git_init(ok_text=f"Initialized empty Git repository in {os.path.abspath('.')}")
 
-        info("Next step: Create a remote repo with 'gitgo new <name>'")
+        if standalone:
+            from pygitgo.utils.cli_io import banner
+            banner("LOCAL SCAFFOLD CONSTRUCTED.", "PROJECT STRUCTURE AND REPOSITORY INITIALIZED.")
+            info(f"Next steps:\n  cd {target_dir}\n  gitgo repo\n  gitgo link <url>")
 
     except Exception as e:
         if os.path.exists(target_dir) and not os.listdir(target_dir):

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -1,10 +1,10 @@
+from pygitgo.utils.cli_io import warning, info, success, error, confirm, banner
 from pygitgo.commands.git_branch import (
     is_branch_exist, get_current_branch, git_new_branch, get_main_branch,
 )
 from pygitgo.commands.stash import (
     git_stash_pop, git_stash_push, git_stash_apply, git_stash_drop
 )
-from pygitgo.utils.colors import warning, info, success, error
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
 import sys
@@ -76,11 +76,10 @@ def jump_operation(args):
     try:
         if has_changes.strip():
             print()
-            info("You have unsaved changes here.")
-            user_input = input("Do you want to move these changes to your new branch? (y/n): ").strip().lower()
-            if user_input != 'y':
+            info("You have unsaved changes in this folder.")
+            if not confirm(f"Move your unsaved edits to branch '{target_branch}'? (y/n): "):
                 print()
-                warning("You cannot switch branches with unsaved changes. Jump canceled.")
+                warning("You cannot switch branches with unsaved edits. Jump canceled.")
                 return
             stash_result = git_stash_push(label="GitGo Jump Auto-Stash", loading_msg="Saving your changes before jumping...")
             if not stash_result:
@@ -93,9 +92,7 @@ def jump_operation(args):
         if not is_branch_exist(target_branch):
             print()
             warning(f"Branch '{target_branch}' does not exist.")
-            user_input = input("Do you want to create it and jump to it? (y/n): ").strip().lower()
-
-            if user_input != 'y':
+            if not confirm(f"Branch '{target_branch}' does not exist yet. Create it and switch to it? (y/n): "):
                 info("Exiting without jumping...")
                 if stashed_code:
                     pop_result = git_stash_pop(loading_msg="Putting your unsaved changes back...")
@@ -130,12 +127,10 @@ def jump_operation(args):
                 print()
                 error("MERGE CONFLICT — your changes clash with the target branch.")
                 print()
-                info("Option [Y]: Stay here and fix the conflict lines yourself.")
-                info("Option [N]: Cancel everything and go back to where you started.")
+                info("Option [Y]: Stay here and fix the conflict lines in your files.")
+                info("Option [N]: Undo the switch and go back to where you started.")
                 print()
-                conflict_choice = input("Do you want to fix it yourself? (y/n): ").strip().lower()
-
-                if conflict_choice != 'y':
+                if not confirm("Fix the conflicts yourself? (y = stay and fix / n = go back): "):
                     undo_jump_operation(original_branch, stashed_code, created_branch)
                     return
                 else:
@@ -148,9 +143,10 @@ def jump_operation(args):
                 drop_result = git_stash_drop(loading_msg="Cleaning up the temporary stash...", ok_text=f"On '{target_branch}'. Your changes came with you.")
                 if not drop_result:
                     warning("Could not clean up the temporary stash. Run 'gitgo state list' to remove it manually.")
-                return
-        else:
-            return
+
+        if not getattr(args, 'nested', False):
+            banner("WORKSPACE RE-POSITIONED. TARGET DEPLOYMENT SECURED.", "ON TARGET BRANCH WITH RE-APPLIED STATE.")
+        return
 
     except KeyboardInterrupt:
         print()

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -1,5 +1,5 @@
 from pygitgo.commands.git_remote import add_remote_origin, confirm_remote_link
-from pygitgo.utils.colors import success, warning, error, info, print_banner
+from pygitgo.utils.cli_io import success, warning, error, info, banner
 from pygitgo.commands.git_core import git_init, git_commit, git_push
 from pygitgo.commands.git_branch import get_current_branch
 from pygitgo.exceptions import GitCommandError, GitGoError
@@ -23,29 +23,34 @@ def _link_interrupt_cleanup(repo_url, initialized, committed, remote_added):
     if committed:
         info("Initial commit was created. Your files are safe.")
         info("Run 'gitgo push' when ready to push to the remote.")
-    elif initialized:
-        info("Git repository was initialized. Your files are safe.")
-        info("Run 'gitgo link <url>' again to complete the setup.")
+        return
+
+    if initialized:
+        try:
+            import shutil
+            import os
+            shutil.rmtree(".git")
+            success("Local Git repository config removed. Files are untouched.")
+        except Exception:
+            warning("Could not auto-remove '.git' folder.")
+            warning("Run: rmdir /s /q .git  (Windows) or  rm -rf .git  (Mac/Linux)")
     else:
-        success("No git state was changed.")
+        success("No Git state was changed. Your files are safe.")
 
 
-def link_core(repo_url, commit_message="Initial commit", silent=False, already_initialized=False):
+def link_core(repo_url, commit_message, silent=False, already_initialized=False):
     if not validate_repo_url(repo_url):
-        raise GitGoError(
-            "\nInvalid repository URL!\n"
-            "Expected format: https://github.com/username/repo.git"
-            "             or: git@github.com:username/repo.git\n"
-        )
+        raise GitGoError(f"Invalid remote repository URL: '{repo_url}'")
 
     initialized = False
     committed = False
     remote_added = False
 
     try:
+        main_branch = get_default_branch()
+
         if already_initialized:
             is_new_repo = True
-            initialized = True
         else:
             is_new_repo = git_init()
             if is_new_repo:
@@ -55,8 +60,8 @@ def link_core(repo_url, commit_message="Initial commit", silent=False, already_i
             add_remote_origin(repo_url)
             remote_added = True
 
-            if confirm_remote_link(ok_text="Remote linked to existing repository."):
-                info("Ready to push with: gitgo push <branch> 'your message'")
+            confirm_remote_link(ok_text="Remote linked to existing repository.")
+            info("Ready to push with: gitgo push <branch> 'your message'")
             return
 
         commit_made = git_commit(commit_message, loading_msg="Creating initial commit...", ok_text="Initial commit created.")
@@ -66,11 +71,10 @@ def link_core(repo_url, commit_message="Initial commit", silent=False, already_i
         add_remote_origin(repo_url)
         remote_added = True
 
-        if not confirm_remote_link():
-            return
-
-        current_branch = get_current_branch()
-        main_branch = get_default_branch()
+        try:
+            current_branch = get_current_branch()
+        except GitCommandError as e:
+            raise GitGoError(f"Could not determine the current branch: {e}")
 
         if current_branch != main_branch:
             run_command(["git", "branch", "-m", main_branch], loading_msg=f"Renaming branch '{current_branch}' to '{main_branch}'...", ok_text=f"Branch renamed to '{main_branch}'.")
@@ -88,16 +92,16 @@ def link_core(repo_url, commit_message="Initial commit", silent=False, already_i
                     loading_msg="Pulling and merging remote content...",
                     ok_text="Remote content merged."
                 )
-            except GitCommandError:
+            except GitCommandError as e:
                 error("Failed to merge remote content. You may need to resolve conflicts manually.")
                 warning(f"Run: git pull origin {main_branch} --allow-unrelated-histories")
                 warning(f"Then: gitgo push {main_branch} 'your message'\n")
-                return
+                raise GitGoError(f"Failed to merge remote content: {e.stderr}" if e.stderr else "Failed to merge remote content.")
 
         git_push(current_branch)
 
         if not silent:
-            print_banner("REPOSITORY INITIALIZED AND DEPLOYED.")
+            banner("REPOSITORY INITIALIZED AND DEPLOYED.", "LOCAL REPOSITORY CONNECTED TO REMOTE ORIGIN.")
             print()
             info("Run 'gitgo undo link' to remove the remote and undo the initial commit.")
 

--- a/src/pygitgo/commands/new.py
+++ b/src/pygitgo/commands/new.py
@@ -1,20 +1,65 @@
-from pygitgo.utils.colors import info, print_banner
+from pygitgo.utils.cli_io import info, error, warning, confirm, success, banner
 from pygitgo.commands.init import init_operation
 from pygitgo.commands.repo import repo_operation
+from pygitgo.utils.platform import get_platform
 from pygitgo.commands.link import link_core
+from pygitgo.exceptions import GitGoError
+import sys
 import os
 
 
+def _assert_not_inside_target(repo_name):
+    # This will abort operation if the user is already inside the folder with same name as repo
+
+    cwd_basename = os.path.basename(os.path.abspath("."))
+
+    if get_platform() == "windows":
+        match = cwd_basename.lower() == repo_name.lower()
+    else:
+        match = cwd_basename == repo_name 
+
+    if match:
+        raise GitGoError(
+            f"\nDirectory mismatch detected.\n\n"
+            f"  You are already inside '{repo_name}/', but you ran: gitgo new {repo_name}\n\n"
+            f"  'gitgo new' creates a NEW folder from scratch. If you want to:\n\n"
+            f"  → Publish this existing folder to GitHub, run:\n"
+            f"      gitgo repo             (creates the GitHub repo)\n"
+            f"      gitgo link <repo-url>  (links and pushes)\n\n"
+            f"  → Start completely fresh in a new folder, cd out first:\n"
+            f"      cd ..\n"
+            f"      gitgo new {repo_name}\n"
+        )
+
+
 def new_operation(args):
+    
+    _assert_not_inside_target(args.name)
+    
     init_operation(args)
 
     os.chdir(args.name)
 
     repo_url = repo_operation(args, silent=True)
 
-    link_core(repo_url, "Initial commit", silent=True, already_initialized=True)
+    try:
+        link_core(repo_url, "Initial commit", silent=True, already_initialized=True)
+    except GitGoError as e:
+        error(str(e))
+        from pygitgo.commands.repo import delete_github_repo, parse_repo_fullname
+        warning(f"An orphaned remote repository was created on GitHub: {repo_url}")
+        info("It needs manual deletion or a retry of 'gitgo link'.")
+        full_name = parse_repo_fullname(repo_url)
+        if full_name:
+            if confirm("Delete the repo I just created on GitHub? (y/n): ", destructive=True):
+                try:
+                    delete_github_repo(full_name)
+                    success("GitHub repository deleted successfully.")
+                except Exception as delete_err:
+                    error(f"Failed to delete: {delete_err}")
+        sys.exit(1)
 
-    print_banner("PROJECT LAUNCHED. SCAFFOLDED, CREATED, AND DEPLOYED.")
+    banner("PROJECT LAUNCHED. SCAFFOLDED, CREATED, AND DEPLOYED.", "LOCAL STRUCTURE ESTABLISHED AND REMOTE SYNCED.")
 
     print()
     info("Run 'gitgo undo link' to remove the remote and undo the initial commit.")

--- a/src/pygitgo/commands/pull.py
+++ b/src/pygitgo/commands/pull.py
@@ -1,5 +1,5 @@
+from pygitgo.utils.cli_io import success, warning, error, info
 from pygitgo.commands.git_branch import get_current_branch
-from pygitgo.utils.colors import success, warning, error, info
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
 from pathlib import Path
@@ -56,6 +56,9 @@ def pull_operation(args):
             loading_msg=f"Downloading latest updates for '{branch}' (auto-saving your code)...",
             ok_text=f"Project is up to date with '{branch}'."
         )
+
+        from pygitgo.utils.cli_io import banner
+        banner("REMOTE SYNCHRONIZED. LATEST CHANGES ACQUIRED.", "LOCAL WORKSPACE UPDATED AND ALIGNED.")
 
     except KeyboardInterrupt:
         print()

--- a/src/pygitgo/commands/push.py
+++ b/src/pygitgo/commands/push.py
@@ -1,6 +1,6 @@
 from pygitgo.commands.staging import get_changed_files, display_file_picker, selective_stage
 from pygitgo.commands.git_branch import git_new_branch, get_current_branch, is_branch_exist
-from pygitgo.utils.colors import info, warning, error, success, print_banner
+from pygitgo.utils.cli_io import info, warning, success, confirm, banner
 from pygitgo.commands.git_core import git_commit, git_push
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.commands.jump import jump_operation
@@ -87,9 +87,12 @@ def push_operation(args):
             elif branch and is_branch_exist(branch):
                 current_branch = get_current_branch()
                 if current_branch != branch:
-                    info(f"Switching to target branch '{branch}'...")
-                    jump_operation(Namespace(branch=branch))
-                    auto_switched_from = current_branch
+                    if confirm(f"Branch '{branch}' already exists. Switch to it before pushing? (y/n): "):
+                        info(f"Switching to target branch '{branch}'...")
+                        jump_operation(Namespace(branch=branch, nested=True))
+                        auto_switched_from = current_branch
+                    else:
+                        raise GitGoError("Push aborted.")
 
             elif not branch:
                 branch = get_current_branch()
@@ -111,7 +114,7 @@ def push_operation(args):
                 return
 
             selective_stage(selected)
-            commit_made = git_commit(message, loading_msg="Commiting selected files...", skip_staging=True)
+            commit_made = git_commit(message, loading_msg="Committing selected files...", skip_staging=True)
 
             if commit_made:
                 git_push(branch)
@@ -139,7 +142,7 @@ def push_operation(args):
                     warning("Make some changes first or check your git remote configuration.")
                     return
 
-        print_banner("MISSION COMPLETE. ALL TARGETS COMMITTED AND PUSHED.")
+        banner("MISSION COMPLETE. ALL TARGETS COMMITTED AND PUSHED.", "REMOTE TARGETS ALIGNED WITH LOCAL EDITS.")
 
         print()
         if auto_switched_from:

--- a/src/pygitgo/commands/repo.py
+++ b/src/pygitgo/commands/repo.py
@@ -1,5 +1,5 @@
-from pygitgo.utils.colors import info, success, warning
 from pygitgo.utils.config import get_config, set_config
+from pygitgo.utils.cli_io import info, warning, banner
 from pygitgo.utils.platform import open_url
 from pygitgo.exceptions import GitGoError
 import subprocess
@@ -64,7 +64,7 @@ def _get_github_token():
     return _prompt_for_token()
 
 
-def create_github_repo(name, private=False, description="", token=None):
+def create_github_repo(name, private=False, description="", token=None, retry_count=0):
     
     if not token:
         token = _get_github_token()
@@ -94,11 +94,13 @@ def create_github_repo(name, private=False, description="", token=None):
         if e.code == 422:
             raise GitGoError(f"Repository '{name}' already exists on GitHub.")
         elif e.code == 401:
+            if retry_count >= 3:
+                raise GitGoError("GitHub authentication failed. Please check your GitHub token.")
             warning("Token is invalid or expired. Clearing saved token...")
             _clear_saved_token()
             warning("Please create a new token. Opening GitHub now...")
             new_token = _prompt_for_token()
-            return create_github_repo(name, private=private, description=description, token=new_token)
+            return create_github_repo(name, private=private, description=description, token=new_token, retry_count=retry_count + 1)
 
         body = e.read().decode("utf-8", errors="replace")
         try:
@@ -143,6 +145,42 @@ def repo_operation(args, silent=False):
         raise e
 
     if not silent:
+        banner("REMOTE TARGET ESTABLISHED. REPOSITORY READY.", "GITHUB TARGET CREATION CONFIRMED.")
         info(f"\nTo connect and push your local code, run:\n  gitgo link {repo_url}")
     return repo_url
+
+
+def parse_repo_fullname(url):
+    s = url.strip()
+    if s.endswith(".git"):
+        s = s[:-4]
+    if "github.com/" in s:
+        parts = s.split("github.com/")
+        if len(parts) > 1:
+            return parts[1]
+    elif "github.com:" in s:
+        parts = s.split("github.com:")
+        if len(parts) > 1:
+            return parts[1]
+    return None
+
+
+def delete_github_repo(full_name, token=None):
+    if not token:
+        token = _get_github_token()
+    req = urllib.request.Request(
+        f"{GITHUB_API}/repos/{full_name}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "GitGo-CLI"
+        }, method="DELETE",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return True
+    except Exception as e:
+        raise GitGoError(f"Failed to delete repository from GitHub: {str(e)}")
+
 

--- a/src/pygitgo/commands/staging.py
+++ b/src/pygitgo/commands/staging.py
@@ -1,6 +1,6 @@
-from pygitgo.utils.colors import success, warning, error
 from pygitgo.utils.executor import run_command
 from pygitgo.exceptions import GitCommandError
+from pygitgo.utils.cli_io import success
 from pick import pick
 
 

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.colors import info, success, warning, error, highlight
+from pygitgo.utils.cli_io import info, success, warning, error, confirm, banner
 from pygitgo.commands.stash import (
     git_stash_apply, git_stash_clear, git_stash_drop,
     git_stash_list, git_stash_push
@@ -51,7 +51,7 @@ def display_save_states(save_state=None):
     print("-" * 60)
 
     for state in save_states:
-        highlight(
+        print(
             f"{state['id']:>2} | {state['date']} | {state['message']}"
         )
 
@@ -130,6 +130,7 @@ def load_state(state_id=None):
             error(f"Failed to load state. There may be a conflict with your current changes.")
             raise GitGoError("Load failed — resolve conflicts first.")
         success(f"State '{selected_state['message']}' restored.")
+        banner("WORKSPACE SNAPSHOT RESTORED.", "SECURE VAULT WORKSPACE RE-APPLIED TO TREE.")
 
     except KeyboardInterrupt:
         print()
@@ -162,6 +163,7 @@ def save_state(state_name=None):
         error(f"Failed to save state '{state_name}'.")
     else:
         success(f"State '{state_name}' saved.")
+        banner("WORKSPACE SNAPSHOT CAPTURED.", "LOCAL EDITS PRESERVED IN GitGo SECURE VAULT.")
 
 
 def delete_state(identifier=None):
@@ -176,8 +178,7 @@ def delete_state(identifier=None):
             return
     else:
         if identifier == '-a':
-            confirm = input("\nAre you sure you want to delete all saved states? (y/n): ").strip().lower()
-            if confirm == 'y':
+            if confirm("Delete all saved states? This cannot be undone. (y/n): ", destructive=True):
                 clear_result = git_stash_clear()
                 if not clear_result:
                     error("Failed to delete all saved states.")

--- a/src/pygitgo/commands/undo.py
+++ b/src/pygitgo/commands/undo.py
@@ -1,5 +1,5 @@
+from pygitgo.utils.cli_io import success, warning, info, confirm, danger, banner
 from pygitgo.commands.git_branch import get_current_branch
-from pygitgo.utils.colors import success, warning, info, error
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
 import sys
@@ -12,25 +12,27 @@ def undo_commit():
         raise GitGoError(
             f"Undo failed — no previous commit to revert. Details: {e}"
         )
+    return True
 
 
 def undo_add():
     run_command(["git", "reset", "HEAD"], loading_msg="Clearing staging area...", ok_text="Staging cleared. Files are back to unstaged.")
+    return True
 
 
 def undo_changes():
-    error("DANGER: This will permanently delete all your new edits and new files!")
-    warning("This action cannot be undone.")
-    confirm = input("Are you sure you want to throw away all changes? (y/n): ")
-    if confirm.lower() != "y":
+    danger("This will permanently delete all your unsaved edits and new files.")
+    warning("There is no way to recover them after this step.")
+    if not confirm("Delete all unsaved changes? Type 'y' to confirm: ", destructive=True):
         info("Canceled. Your files are safe.")
-        return
+        return False
 
     reset_done = False
     try:
         run_command(["git", "reset", "--hard", "HEAD"], loading_msg="Throwing away edits...", ok_text="Edits discarded.")
         reset_done = True
         run_command(["git", "clean", "-fd"], loading_msg="Removing new files...", ok_text="Working tree reset. All changes discarded.")
+        return True
 
     except KeyboardInterrupt:
         print()
@@ -58,6 +60,7 @@ def undo_link():
     except GitCommandError:
         info("Remote removed. Could not undo the commit (none or multiple found).")
         info("Run 'gitgo undo commit' separately if needed.")
+    return True
 
 
 def undo_push():
@@ -66,12 +69,12 @@ def undo_push():
     except GitCommandError as e:
         raise GitGoError(f"Could not determine the current branch: {e}")
 
-    error("DANGER: This force-pushes to the remote. Other collaborators will be affected.")
-    warning("Only use this if no one else has pulled the commit you are reverting.")
-    confirm = input("Are you sure you want to undo the last push? (y/n): ")
-    if confirm.lower() != "y":
+    danger("This will remove your last upload from GitHub using a force-push.")
+    warning("If anyone else already downloaded that commit, this will cause problems for them.")
+    warning("Only continue if you are the only person working on this branch.")
+    if not confirm("Remove the last push from GitHub? Type 'y' to confirm: ", destructive=True):
         info("Canceled. Remote is unchanged.")
-        return
+        return False
 
     try:
         run_command(["git", "reset", "--soft", "HEAD~"], loading_msg="Reverting last commit locally...", ok_text="Last commit reverted locally.")
@@ -85,24 +88,30 @@ def undo_push():
             ok_text=f"Last push reverted. Remote '{branch}' is back to the previous commit."
         )
         info("Your files are still staged locally. Edit and push again when ready.")
+        return True
     except GitCommandError as e:
-        warning("Local commit was undone, but the force-push failed.")
-        warning(f"Run manually: git push --force origin {branch}")
+        warning("Local and remote have diverged!")
+        warning("The local commit was reverted, but force-pushing to the remote failed.")
+        warning(f"To recover, run manually: git push --force origin {branch}")
         raise GitGoError(f"Force-push failed: {e}")
 
 
 def undo_operation(args):
     action = args.action
 
+    success_flag = False
     if action == "commit":
-        undo_commit()
+        success_flag = undo_commit()
     elif action == "add":
-        undo_add()
+        success_flag = undo_add()
     elif action == "changes":
-        undo_changes()
+        success_flag = undo_changes()
     elif action == "link":
-        undo_link()
+        success_flag = undo_link()
     elif action == "push":
-        undo_push()
+        success_flag = undo_push()
     else:
         raise GitGoError(f"Unknown undo operation: {action}")
+
+    if success_flag:
+        banner("ACTION ROLLBACK. WORKSPACE RESTORED.", "PREVIOUS STATE RE-ESTABLISHED SUCCESSFULLY.")

--- a/src/pygitgo/commands/user.py
+++ b/src/pygitgo/commands/user.py
@@ -1,6 +1,6 @@
+from pygitgo.utils.cli_io import info, warning, banner
 from pygitgo.auth.manager import login, logout
 from pygitgo.auth.account import get_user
-from pygitgo.utils.colors import info, warning
 from pygitgo.exceptions import GitGoError
 import shutil
 
@@ -28,7 +28,8 @@ def user_operation(args):
         return
     
     if action == 'login':
-        login()
+        if login():
+            banner("IDENTITY VERIFIED. ACCESS GRANTED.", "GITHUB SECURE KEYPAIR REGISTERED AND ENABLED.")
     elif action == 'logout':
         logout()
     else:

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -1,6 +1,6 @@
 from pygitgo.utils.update_checker import check_for_updates_background, check_for_updates
 from pygitgo.utils.bootstrap import ensure_first_run_setup
-from pygitgo.utils.colors import info, warning, error
+from pygitgo.utils.cli_io import info, warning, error
 from pygitgo.commands.config import config_operation
 from pygitgo.commands.state import state_operation
 from pygitgo.commands.undo import undo_operation
@@ -294,7 +294,7 @@ def main():
         elif args.command == "new":
             new_operation(args)
         elif args.command == "init":
-            init_operation(args)
+            init_operation(args, standalone=True)
     except GitGoError as e:
         error(f"{e}")
         sys.exit(1)

--- a/src/pygitgo/utils/bootstrap.py
+++ b/src/pygitgo/utils/bootstrap.py
@@ -1,5 +1,5 @@
+from pygitgo.utils.cli_io import error, info
 from pygitgo.exceptions import GitGoError
-from pygitgo.utils.colors import error, info
 import shutil
 
 

--- a/src/pygitgo/utils/cli_io.py
+++ b/src/pygitgo/utils/cli_io.py
@@ -1,0 +1,35 @@
+from pygitgo.utils.colors import RED, GREEN, YELLOW, BLUE, CYAN, RESET
+import shutil
+
+
+def confirm(prompt, destructive=False):
+    prefix = ""
+    if destructive:
+        prefix = f"{RED}DANGER: {RESET}"
+    user_input = input(f"{prefix}{prompt}").strip().lower()
+    return user_input == 'y'
+
+def danger(msg):
+    print(f"{RED}DANGER: {msg.strip()}{RESET}")
+
+def warning(msg):
+    print(f"{YELLOW}WARNING: {msg.strip()}{RESET}")
+
+def error(msg):
+    print(f"{RED}{msg.strip()}{RESET}")
+
+def info(msg):
+    print(f"{BLUE}{msg.strip()}{RESET}")
+
+def success(msg):
+    print(f"{GREEN}{msg.strip()}{RESET}")
+
+def banner(title, subtitle=""):
+    width = min(shutil.get_terminal_size().columns, 72)
+    print()
+    print(GREEN + ("=" * width) + RESET)
+    print(GREEN + title.center(width) + RESET)
+    if subtitle:
+        print(CYAN + subtitle.center(width) + RESET)
+    print(GREEN + ("=" * width) + RESET)
+    print()

--- a/src/pygitgo/utils/colors.py
+++ b/src/pygitgo/utils/colors.py
@@ -1,34 +1,6 @@
-import shutil
-
 RED = "\033[31m"
 GREEN = "\033[32m"
 YELLOW = "\033[33m"
 BLUE = "\033[34m"
 CYAN = "\033[36m"
 RESET = "\033[0m"
-
-
-def info(msg):
-    print(f"{BLUE}{msg.strip()}{RESET}")
-
-def success(msg):
-    print(f"{GREEN}{msg.strip()}{RESET}")
-
-def warning(msg):
-    print(f"{YELLOW}{msg.strip()}{RESET}")
-
-def error(msg):
-    print(f"{RED}{msg.strip()}{RESET}")
-
-def highlight(msg):
-    print(f"{CYAN}{msg.strip()}{RESET}")
-
-def print_banner(title, subtitle="AWAITING NEXT ORDERS."):
-    width = min(shutil.get_terminal_size().columns, 72)
-    print()
-    print(GREEN + ("=" * width) + RESET)
-    print(GREEN + title.center(width) + RESET)
-    if subtitle:
-        print(CYAN + subtitle.center(width) + RESET)
-    print(GREEN + ("=" * width) + RESET)
-    print()

--- a/src/pygitgo/utils/config.py
+++ b/src/pygitgo/utils/config.py
@@ -1,5 +1,5 @@
+from pygitgo.utils.cli_io import error, success
 from pygitgo.utils.executor import run_command
-from pygitgo.utils.colors import error, warning, success, info
 from pygitgo.exceptions import GitCommandError
 import subprocess
 

--- a/src/pygitgo/utils/executor.py
+++ b/src/pygitgo/utils/executor.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.colors import error, info, success, warning
+from pygitgo.utils.cli_io import error, info, success, warning, confirm, danger
 from pygitgo.exceptions import GitCommandError
 from yaspin import yaspin
 import subprocess
@@ -47,17 +47,15 @@ def run_command(command, return_complete=False, loading_msg=None, ok_text=None, 
             stderr = f"Command not found or execution failed: {str(e)}"
 
         if "detected dubious ownership" in stderr:
-            error(f"SECURITY ALERT: {stderr}")
-            warning("This is a known Git security feature in shared environments (like Termux).")
-            info("GitGo can fix this by adding this directory to your safe list.")
+            danger("Git blocked this folder for security reasons (dubious ownership).")
+            warning("This usually happens in shared environments like Termux or network drives.")
+            info("GitGo can add this folder to Git's trusted list so commands work here.")
 
             path_match = re.search(r"repository at '(.+)'", stderr)
             repo_path = path_match.group(1) if path_match else os.getcwd()
 
-            info(f"Directory to trust: {repo_path}")
-            confirm = input("\nDo you want GitGo to add this directory as an exception? (y/n): ").strip().lower()
-
-            if confirm == 'y':
+            info(f"Folder to trust: {repo_path}")
+            if confirm("Trust this folder and allow Git commands to run in it? (y/n): "):
                 info("Running security fix...")
                 fix_command = ["git", "config", "--global", "--add", "safe.directory", repo_path]
                 try:

--- a/src/pygitgo/utils/platform.py
+++ b/src/pygitgo/utils/platform.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.colors import warning, info
+from pygitgo.utils.cli_io import warning, info
 import webbrowser
 import subprocess
 import platform

--- a/src/pygitgo/utils/update_checker.py
+++ b/src/pygitgo/utils/update_checker.py
@@ -1,11 +1,11 @@
-import json
-import threading
-import urllib.request
-import urllib.error
+from pygitgo.utils.cli_io import info, warning
 from datetime import datetime, timedelta
 from pathlib import Path
+import urllib.request
+import urllib.error
+import threading
+import json
 
-from pygitgo.utils.colors import info, warning
 
 
 CACHE_DIR = Path.home() / ".gitgo"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from pygitgo.exceptions import GitGoError
 from pathlib import Path
 import pytest
 import sys
@@ -6,8 +7,6 @@ import sys
 src_dir = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(src_dir))
 
-
-from pygitgo.exceptions import GitGoError
 
 def capture_system_exit_code(function):
     try:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,6 +1,5 @@
-import pytest
-from pygitgo.exceptions import GitCommandError
 from pygitgo.auth.account import get_user, set_user, ensure_user_configure, sanitize_signing_config
+from pygitgo.exceptions import GitCommandError
 
 
 

--- a/tests/test_cli_io.py
+++ b/tests/test_cli_io.py
@@ -1,0 +1,52 @@
+from pygitgo.utils.cli_io import confirm, danger, warning, error, info, success, banner
+from pygitgo.utils.colors import RED, GREEN, YELLOW, BLUE, RESET
+import pytest
+import os
+
+def test_confirm_yes(mocker):
+    mocker.patch("builtins.input", return_value="y")
+    assert confirm("Proceed?") is True
+
+def test_confirm_no(mocker):
+    mocker.patch("builtins.input", return_value="n")
+    assert confirm("Proceed?") is False
+
+def test_confirm_destructive(mocker):
+    mock_input = mocker.patch("builtins.input", return_value="y")
+    assert confirm("Proceed?", destructive=True) is True
+    # check that DANGER: prefix is included in prompt
+    mock_input.assert_called_once_with(f"{RED}DANGER: {RESET}Proceed?")
+
+def test_danger(mocker):
+    mock_print = mocker.patch("builtins.print")
+    danger("irreversible action")
+    mock_print.assert_called_once_with(f"{RED}DANGER: irreversible action{RESET}")
+
+def test_warning(mocker):
+    mock_print = mocker.patch("builtins.print")
+    warning("recoverable risk")
+    mock_print.assert_called_once_with(f"{YELLOW}WARNING: recoverable risk{RESET}")
+
+def test_error(mocker):
+    mock_print = mocker.patch("builtins.print")
+    error("failed operation")
+    mock_print.assert_called_once_with(f"{RED}failed operation{RESET}")
+
+def test_info(mocker):
+    mock_print = mocker.patch("builtins.print")
+    info("some info")
+    mock_print.assert_called_once_with(f"{BLUE}some info{RESET}")
+
+def test_success(mocker):
+    mock_print = mocker.patch("builtins.print")
+    success("action done")
+    mock_print.assert_called_once_with(f"{GREEN}action done{RESET}")
+
+def test_banner(mocker):
+    mock_print = mocker.patch("builtins.print")
+    mocker.patch("shutil.get_terminal_size", return_value=os.terminal_size((80, 24)))
+    
+    banner("TITLE", "SUBTITLE")
+    
+    # Check that print was called to output the banner
+    assert mock_print.call_count >= 4

--- a/tests/test_cli_io.py
+++ b/tests/test_cli_io.py
@@ -1,6 +1,5 @@
 from pygitgo.utils.cli_io import confirm, danger, warning, error, info, success, banner
 from pygitgo.utils.colors import RED, GREEN, YELLOW, BLUE, RESET
-import pytest
 import os
 
 def test_confirm_yes(mocker):

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -4,26 +4,23 @@ from argparse import Namespace
 import pytest
 
 
-def test_config_operation_not_valid_keys(mocker):
-    fake_error = mocker.patch('pygitgo.commands.config.error')
-    fake_warning = mocker.patch('pygitgo.commands.config.warning')
-    
-    VALID_KEYS = ["default-branch", "default-message"]
+from pygitgo.exceptions import GitGoError
 
+
+def test_config_operation_not_valid_keys(mocker):
+    VALID_KEYS = ["default-branch", "default-message"]
     key = "not-valid"
     value = "true"
     args = Namespace(key=key, action="set", value=value)
 
-    assert capture_system_exit_code(lambda: config_operation(args)) == 0
+    with pytest.raises(GitGoError, match="Invalid configuration key"):
+        config_operation(args)
 
-    fake_error.assert_called_with(f"\nInvalid configuration key: '{key}'")
-    fake_warning.assert_called_with(f"Valid keys are: {', '.join(VALID_KEYS)}\n")
 
 def test_config_operation_set_no_value(mocker):
-    fake_error = mocker.patch('pygitgo.commands.config.error')
     args = Namespace(key="default-branch", action="set")
-    config_operation(args)
-    fake_error.assert_called_with("\nYou must provide a value to set!\n")
+    with pytest.raises(GitGoError, match="You must provide a value to set"):
+        config_operation(args)
 
 def test_config_operation_set_ok(mocker):
     fake_set = mocker.patch('pygitgo.commands.config.set_config')

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -1,5 +1,4 @@
 from pygitgo.commands.config import config_operation
-from conftest import capture_system_exit_code
 from argparse import Namespace
 import pytest
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,92 @@
+from pygitgo.utils.executor import run_command
+from pygitgo.exceptions import GitCommandError
+import subprocess
+import pytest
+
+def test_run_command_success(mocker):
+    mock_run = mocker.patch("subprocess.run")
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = "hello world\n"
+    mock_run.return_value = mock_result
+
+    res = run_command(["echo", "hello"])
+    assert res == "hello world"
+    mock_run.assert_called_once_with(["echo", "hello"], check=True, capture_output=True, text=True)
+
+def test_run_command_success_complete(mocker):
+    mock_run = mocker.patch("subprocess.run")
+    mock_result = mocker.MagicMock()
+    mock_run.return_value = mock_result
+
+    res = run_command(["echo", "hello"], return_complete=True)
+    assert res == mock_result
+
+def test_run_command_spinner_success(mocker):
+    mock_run = mocker.patch("subprocess.run")
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = "done"
+    mock_run.return_value = mock_result
+
+    # Mock yaspin spinner
+    mock_yaspin = mocker.patch("pygitgo.utils.executor.yaspin")
+    mock_spinner = mocker.MagicMock()
+    mock_yaspin.return_value = mock_spinner
+
+    res = run_command(["echo", "hello"], loading_msg="Loading...", ok_text="Ok")
+    assert res == "done"
+    mock_spinner.start.assert_called_once()
+    assert mock_spinner.text == "Ok"
+    mock_spinner.ok.assert_called_once_with("✔")
+
+def test_run_command_called_process_error(mocker):
+    mock_run = mocker.patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, ["cmd"], stderr="some error"))
+    
+    with pytest.raises(GitCommandError) as exc_info:
+        run_command(["cmd"])
+    
+    assert exc_info.value.returncode == 1
+    assert exc_info.value.stderr == "some error"
+
+def test_run_command_os_error(mocker):
+    mock_run = mocker.patch("subprocess.run", side_effect=OSError("file not found"))
+    
+    with pytest.raises(GitCommandError) as exc_info:
+        run_command(["cmd"])
+    
+    assert exc_info.value.returncode == 1
+    assert "Command not found or execution failed" in exc_info.value.stderr
+
+def test_run_command_dubious_ownership_confirm(mocker):
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.side_effect = [
+        subprocess.CalledProcessError(1, ["git", "status"], stderr="fatal: detected dubious ownership in repository at 'C:/path'"),
+        mocker.MagicMock(stdout="trusted success"),  # fix_command call success
+        mocker.MagicMock(stdout="final result")       # retry call success
+    ]
+
+    mock_danger = mocker.patch("pygitgo.utils.executor.danger")
+    mock_warning = mocker.patch("pygitgo.utils.executor.warning")
+    mock_info = mocker.patch("pygitgo.utils.executor.info")
+    mock_success = mocker.patch("pygitgo.utils.executor.success")
+    mock_confirm = mocker.patch("pygitgo.utils.executor.confirm", return_value=True)
+
+    res = run_command(["git", "status"])
+    assert res == "final result"
+    mock_danger.assert_called_once_with("Git blocked this folder for security reasons (dubious ownership).")
+    mock_confirm.assert_called_once()
+    mock_success.assert_called_once_with("Directory trusted. Retrying command...")
+
+def test_run_command_dubious_ownership_decline(mocker):
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "status"], stderr="fatal: detected dubious ownership in repository at 'C:/path'")
+
+    mock_danger = mocker.patch("pygitgo.utils.executor.danger")
+    mock_warning = mocker.patch("pygitgo.utils.executor.warning")
+    mock_info = mocker.patch("pygitgo.utils.executor.info")
+    mock_confirm = mocker.patch("pygitgo.utils.executor.confirm", return_value=False)
+
+    with pytest.raises(GitCommandError):
+        run_command(["git", "status"])
+    
+    mock_confirm.assert_called_once()
+    mock_warning.assert_called_with("Fix declined. Operations in this directory will continue to fail.")

--- a/tests/test_git_branch.py
+++ b/tests/test_git_branch.py
@@ -1,7 +1,6 @@
 from pygitgo.commands.git_branch import (
     git_new_branch, get_current_branch, is_branch_exist
 )
-from unittest.mock import call
 import pytest
 
 

--- a/tests/test_git_branch.py
+++ b/tests/test_git_branch.py
@@ -30,7 +30,7 @@ def test_git_branch_exists_jump_yes(mocker):
     result = git_new_branch(branch_name)
 
     assert result == "existing-branch"
-    fake_error.assert_called_once_with(f"Failed to create branch '{branch_name}'! It may already exist.")
+    fake_error.assert_called_once_with(f"Failed to create branch '{branch_name}'. It may already exist.")
 
     args = fake_jump.call_args[0][0]
     assert args.branch == branch_name
@@ -48,7 +48,7 @@ def test_git_branch_exists_jump_no(mocker):
 
     with pytest.raises(GitGoError):
         git_new_branch(branch_name)
-    fake_error.assert_called_once_with(f"Failed to create branch '{branch_name}'! It may already exist.")
+    fake_error.assert_called_once_with(f"Failed to create branch '{branch_name}'. It may already exist.")
     fake_jump.assert_not_called()
 
 

--- a/tests/test_git_core.py
+++ b/tests/test_git_core.py
@@ -1,8 +1,6 @@
 from pygitgo.commands.git_core import (
     git_commit, git_init, git_push
 )
-from unittest.mock import call
-import pytest
 
 
 def test_git_commit(mocker):

--- a/tests/test_git_core.py
+++ b/tests/test_git_core.py
@@ -16,7 +16,7 @@ def test_git_commit(mocker):
 
     fake_run.assert_any_call(
         ['git', 'commit', '-S', '-m', 'Testing the commit feature'],
-        loading_msg="Commiting changes...",
+        loading_msg="Committing changes...",
         ok_text="Changes committed."
     )
 

--- a/tests/test_git_remote.py
+++ b/tests/test_git_remote.py
@@ -23,20 +23,22 @@ def test_confirm_remote_link_success(mocker):
     )
 
 def test_confirm_remote_link_fallback(mocker):
-    from pygitgo.exceptions import GitCommandError
+    from pygitgo.exceptions import GitCommandError, GitGoError
     fake_run = mocker.patch(
         'pygitgo.commands.git_remote.run_command',
         side_effect=GitCommandError(["git", "ls-remote"])
     )
+    fake_info = mocker.patch('pygitgo.commands.git_remote.info')
 
-    result = confirm_remote_link()
-    assert result == False
+    with pytest.raises(GitGoError, match="Connection failed"):
+        confirm_remote_link()
 
     fake_run.assert_called_once_with(
-        ["git", "ls-remote", "origin"], 
+        ["git", "ls-remote", "origin"],
         loading_msg="Testing connection to remote...",
         ok_text="Remote is reachable."
     )
+    fake_info.assert_called_once_with("Run:  git remote -v   to inspect your current remote.")
 
 def test_handle_rebase(mocker):
     from pygitgo.exceptions import GitGoError

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,7 +6,6 @@ from pygitgo.commands.init import (
     init_operation,
 )
 import pytest
-import os
 
 
 SAMPLE_AVAILABLE = {

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -1,0 +1,65 @@
+import subprocess
+from pathlib import Path
+
+
+def _git(cwd, *args):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_integration_init_commit_and_branch(tmp_path):
+    repo = tmp_path / "project"
+    repo.mkdir()
+
+    _git(repo, "init", "-b", "main")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "-c", "commit.gpgsign=false", "commit", "-m", "Initial commit")
+
+    log = _git(repo, "log", "-1", "--pretty=%s")
+    assert log.stdout.strip() == "Initial commit"
+
+    branch = _git(repo, "branch", "--show-current")
+    assert branch.stdout.strip() == "main"
+
+
+def test_integration_bare_remote_and_push(tmp_path):
+    bare = tmp_path / "remote.git"
+    work = tmp_path / "project"
+    work.mkdir()
+
+    _git(tmp_path, "init", "--bare", str(bare))
+    _git(work, "init", "-b", "main")
+    _git(work, "remote", "add", "origin", str(bare))
+    (work / "file.txt").write_text("content\n", encoding="utf-8")
+    _git(work, "add", "file.txt")
+    _git(work, "-c", "commit.gpgsign=false", "commit", "-m", "first")
+    _git(work, "push", "-u", "origin", "main")
+
+    ls = _git(bare, "branch")
+    assert "main" in ls.stdout
+
+
+def test_integration_stash_save_and_list(tmp_path):
+    repo = tmp_path / "project"
+    repo.mkdir()
+
+    _git(repo, "init", "-b", "main")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "-c", "commit.gpgsign=false", "commit", "-m", "initial")
+
+    (repo / "wip.txt").write_text("draft\n", encoding="utf-8")
+    _git(repo, "add", "wip.txt")
+    _git(repo, "stash", "push", "-m", "GitGo Auto-Save")
+
+    stash_list = _git(repo, "stash", "list")
+    assert "GitGo Auto-Save" in stash_list.stdout
+
+    status = _git(repo, "status", "--porcelain")
+    assert status.stdout.strip() == ""

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -1,14 +1,23 @@
+import os
 import subprocess
 from pathlib import Path
 
 
 def _git(cwd, *args):
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
     return subprocess.run(
         ["git", *args],
         cwd=cwd,
         check=True,
         capture_output=True,
         text=True,
+        env=env,
     )
 
 

--- a/tests/test_integration_git.py
+++ b/tests/test_integration_git.py
@@ -1,6 +1,5 @@
-import os
 import subprocess
-from pathlib import Path
+import os
 
 
 def _git(cwd, *args):

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -1,5 +1,5 @@
 from pygitgo.commands.jump import undo_jump_operation, jump_operation
-from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.exceptions import GitCommandError
 from conftest import capture_system_exit_code
 from argparse import Namespace
 import pytest
@@ -90,7 +90,7 @@ def test_jump_operation_has_changes_exit(mocker):
     mocker.patch('pygitgo.commands.jump.run_command', return_value='M file.txt')
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('main'))) == 0
-    fake_warning.assert_any_call("You cannot switch branches with unsaved changes. Jump canceled.")
+    fake_warning.assert_any_call("You cannot switch branches with unsaved edits. Jump canceled.")
 
 
 def test_jump_operation_has_changes_moves_to_branch(mocker):
@@ -257,3 +257,51 @@ def test_jump_operation_merge_conflict_stay(mocker):
     fake_warning.assert_any_call("Open your editor and fix the conflict lines.")
     fake_info.assert_any_call("Your stash backup is still saved. Run 'gitgo state list' to see it.")
     fake_drop.assert_not_called()
+
+
+def test_jump_keyboard_interrupt_during_checkout(mocker):
+    mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='main')
+    mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
+    mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
+    mock_warning = mocker.patch('pygitgo.commands.jump.warning')
+    mock_cleanup = mocker.patch('pygitgo.commands.jump._jump_interrupt_cleanup')
+
+    def side_effect(cmd, *args, **kwargs):
+        if cmd == ['git', 'status', '--porcelain']:
+            return ''
+        if cmd == ['git', 'checkout', 'feature']:
+            raise KeyboardInterrupt()
+        return 'ok'
+
+    mocker.patch('pygitgo.commands.jump.run_command', side_effect=side_effect)
+
+    with pytest.raises(SystemExit) as exc_info:
+        jump_operation(make_args('feature'))
+
+    assert exc_info.value.code == 130
+    mock_warning.assert_called_with("Jump interrupted (Ctrl+C).")
+    mock_cleanup.assert_called_once_with('main', False, None)
+
+
+def test_jump_keyboard_interrupt_after_stash(mocker):
+    mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='main')
+    mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
+    mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
+    mocker.patch('pygitgo.commands.jump.confirm', return_value=True)
+    mocker.patch('pygitgo.commands.jump.git_stash_push', return_value=True)
+    mock_cleanup = mocker.patch('pygitgo.commands.jump._jump_interrupt_cleanup')
+
+    def side_effect(cmd, *args, **kwargs):
+        if cmd == ['git', 'status', '--porcelain']:
+            return 'M file.txt'
+        if cmd[0] == 'git' and cmd[1] == 'checkout':
+            raise KeyboardInterrupt()
+        return 'ok'
+
+    mocker.patch('pygitgo.commands.jump.run_command', side_effect=side_effect)
+
+    with pytest.raises(SystemExit) as exc_info:
+        jump_operation(make_args('feature'))
+
+    assert exc_info.value.code == 130
+    mock_cleanup.assert_called_once_with('main', True, None)

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,14 +1,14 @@
-import pytest
-from argparse import Namespace
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.commands.link import link_operation
+from argparse import Namespace
+import pytest
 
 
 def test_link_invalid_url():
     args = Namespace(url="invalid-url", message="Initial commit")
     with pytest.raises(GitGoError) as exc_info:
         link_operation(args)
-    assert "Invalid repository URL!" in str(exc_info.value)
+    assert "Invalid remote repository URL:" in str(exc_info.value)
 
 
 def test_link_existing_repo(mocker):
@@ -101,7 +101,96 @@ def test_link_new_repo_with_remote_refs_pull_failure(mocker):
     )
 
     args = Namespace(url="git@github.com:user/repo.git", message="Initial commit")
-    link_operation(args)
+    with pytest.raises(GitGoError):
+        link_operation(args)
 
     fake_error.assert_called_once_with("Failed to merge remote content. You may need to resolve conflicts manually.")
     fake_warning.assert_any_call("Run: git pull origin main --allow-unrelated-histories")
+
+
+def test_link_core_already_initialized_commits_and_pushes(mocker):
+    from pygitgo.commands.link import link_core
+
+    mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    fake_init = mocker.patch("pygitgo.commands.link.git_init")
+    fake_commit = mocker.patch("pygitgo.commands.link.git_commit", return_value=True)
+    fake_add_remote = mocker.patch("pygitgo.commands.link.add_remote_origin")
+    mocker.patch("pygitgo.commands.link.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.link.get_default_branch", return_value="main")
+    mocker.patch("pygitgo.commands.link.run_command", return_value="")
+    fake_push = mocker.patch("pygitgo.commands.link.git_push")
+
+    link_core(
+        "https://github.com/user/repo.git",
+        "Initial commit",
+        silent=True,
+        already_initialized=True,
+    )
+
+    fake_init.assert_not_called()
+    fake_commit.assert_called_once_with(
+        "Initial commit",
+        loading_msg="Creating initial commit...",
+        ok_text="Initial commit created.",
+    )
+    fake_add_remote.assert_called_once_with("https://github.com/user/repo.git")
+    fake_push.assert_called_once_with("main")
+
+
+def test_link_keyboard_interrupt_during_commit(mocker):
+    from pygitgo.commands.link import link_core
+
+    mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_init", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_commit", side_effect=KeyboardInterrupt())
+    mock_warning = mocker.patch("pygitgo.commands.link.warning")
+    mock_cleanup = mocker.patch("pygitgo.commands.link._link_interrupt_cleanup")
+
+    with pytest.raises(SystemExit) as exc_info:
+        link_core("https://github.com/user/repo.git", "Initial commit")
+
+    assert exc_info.value.code == 130
+    mock_warning.assert_called_once_with("Link interrupted (Ctrl+C).")
+    mock_cleanup.assert_called_once_with(
+        "https://github.com/user/repo.git",
+        True,
+        False,
+        False,
+    )
+
+
+def test_link_keyboard_interrupt_after_remote_added(mocker):
+    from pygitgo.commands.link import link_core
+
+    mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_init", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_commit", return_value=True)
+    mocker.patch("pygitgo.commands.link.add_remote_origin")
+    mocker.patch("pygitgo.commands.link.get_current_branch", side_effect=KeyboardInterrupt())
+    mock_cleanup = mocker.patch("pygitgo.commands.link._link_interrupt_cleanup")
+
+    with pytest.raises(SystemExit) as exc_info:
+        link_core("https://github.com/user/repo.git", "Initial commit")
+
+    assert exc_info.value.code == 130
+    mock_cleanup.assert_called_once_with(
+        "https://github.com/user/repo.git",
+        True,
+        True,
+        True,
+    )
+
+
+def test_link_existing_repo_failure(mocker):
+    mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    mocker.patch("pygitgo.commands.link.git_init", return_value=False)
+    fake_add_remote = mocker.patch("pygitgo.commands.link.add_remote_origin")
+    fake_confirm = mocker.patch("pygitgo.commands.link.confirm_remote_link", side_effect=GitGoError("Connection failed"))
+
+    args = Namespace(url="git@github.com:user/repo.git", message="Initial commit")
+    with pytest.raises(GitGoError) as exc_info:
+        link_operation(args)
+    
+    assert "Connection failed" in str(exc_info.value)
+    fake_add_remote.assert_called_once_with("git@github.com:user/repo.git")
+    fake_confirm.assert_called_once_with(ok_text="Remote linked to existing repository.")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,116 @@
+import sys
+import pytest
+from pygitgo.exceptions import GitGoError
+from pygitgo.main import main
+
+
+@pytest.fixture
+def _patch_startup(mocker):
+    mocker.patch("pygitgo.main.ensure_first_run_setup")
+    mocker.patch("pygitgo.main.check_for_updates_background")
+
+
+def test_main_version_flag(mocker, capsys):
+    mocker.patch.object(sys, "argv", ["gitgo", "-v"])
+    mocker.patch("pygitgo.main.get_version", return_value="1.8.2")
+    mock_check = mocker.patch("pygitgo.main.check_for_updates")
+
+    main()
+
+    captured = capsys.readouterr()
+    assert "GitGo 1.8.2" in captured.out
+    mock_check.assert_called_once_with("1.8.2")
+
+
+def test_main_ready_flag(mocker, capsys):
+    mocker.patch.object(sys, "argv", ["gitgo", "--ready"])
+    mocker.patch("pygitgo.main.get_version", return_value="1.8.2")
+    mock_check = mocker.patch("pygitgo.main.check_for_updates")
+    mock_info = mocker.patch("pygitgo.main.info")
+
+    main()
+
+    mock_info.assert_called_once()
+    mock_check.assert_called_once_with("1.8.2")
+
+
+def test_main_no_command_prints_help(mocker, capsys, _patch_startup):
+    mocker.patch.object(sys, "argv", ["gitgo"])
+
+    main()
+
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out.lower() or "Commands" in captured.out
+
+
+@pytest.mark.parametrize("command,handler", [
+    ("jump", "jump_operation"),
+    ("link", "link_operation"),
+    ("push", "push_operation"),
+    ("state", "state_operation"),
+    ("user", "user_operation"),
+    ("config", "config_operation"),
+    ("undo", "undo_operation"),
+    ("pull", "pull_operation"),
+    ("repo", "repo_operation"),
+    ("new", "new_operation"),
+    ("init", "init_operation"),
+])
+def test_main_dispatches_command(mocker, _patch_startup, command, handler):
+    mocker.patch.object(sys, "argv", ["gitgo", command] + _argv_tail(command))
+    mock_handler = mocker.patch(f"pygitgo.main.{handler}")
+
+    main()
+
+    mock_handler.assert_called_once()
+
+
+def _argv_tail(command):
+    tails = {
+        "jump": ["feature"],
+        "link": ["https://github.com/user/repo.git"],
+        "push": [],
+        "state": ["list"],
+        "user": [],
+        "config": ["get", "default-branch"],
+        "undo": ["commit"],
+        "pull": [],
+        "repo": [],
+        "new": ["my-app"],
+        "init": ["my-app"],
+    }
+    return tails[command]
+
+
+def test_main_init_passes_standalone(mocker, _patch_startup):
+    mocker.patch.object(sys, "argv", ["gitgo", "init", "my-app"])
+    mock_init = mocker.patch("pygitgo.main.init_operation")
+
+    main()
+
+    mock_init.assert_called_once()
+    assert mock_init.call_args.kwargs["standalone"] is True
+
+
+def test_main_gitgo_error_exits_one(mocker, _patch_startup):
+    mocker.patch.object(sys, "argv", ["gitgo", "push"])
+    mocker.patch("pygitgo.main.push_operation", side_effect=GitGoError("push failed"))
+    mock_error = mocker.patch("pygitgo.main.error")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+    mock_error.assert_called_once_with("push failed")
+
+
+def test_main_keyboard_interrupt_exits_130(mocker, _patch_startup):
+    mocker.patch.object(sys, "argv", ["gitgo", "push"])
+    mocker.patch("pygitgo.main.push_operation", side_effect=KeyboardInterrupt())
+    mock_warning = mocker.patch("pygitgo.main.warning")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 130
+    mock_warning.assert_called_once_with("Operation canceled.")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
-import sys
-import pytest
 from pygitgo.exceptions import GitGoError
 from pygitgo.main import main
+import pytest
+import sys
 
 
 @pytest.fixture

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,7 +1,6 @@
 from pygitgo.auth.manager import login, logout
-from pathlib import Path
 from unittest.mock import call
-import pytest
+from pathlib import Path
 
 
 def test_login_already_logged_in_with_managed_key(mocker):
@@ -143,4 +142,4 @@ def test_logout_success(mocker):
     assert fake_remove.call_count == 2
     fake_run.assert_any_call(["git", "config", "--global", "--unset-all", "user.name"], loading_msg="Clearing Git username...", ok_text="Git username cleared.")
     fake_run.assert_any_call(["git", "config", "--global", "--unset-all", "user.email"], loading_msg="Clearing Git email...", ok_text="Git email cleared.")
-    fake_success.assert_called_once_with("User successfully logout")
+    fake_success.assert_called_once_with("User successfully logged out.")

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -1,5 +1,7 @@
+from pygitgo.commands.new import new_operation, _assert_not_inside_target
 from unittest.mock import patch, MagicMock
-from pygitgo.commands.new import new_operation
+from pygitgo.exceptions import GitGoError
+import pytest
 
 
 @patch("pygitgo.commands.new.init_operation")
@@ -25,3 +27,64 @@ def test_new_operation_quickstart(mock_chdir, mock_link_core, mock_repo_operatio
 
     captured = capsys.readouterr()
     assert "undo link" in captured.out
+
+def test_guard_raises_when_already_inside(tmp_path, monkeypatch):
+    target = tmp_path / "my-app"
+    target.mkdir()
+    monkeypatch.chdir(target)
+    with pytest.raises(GitGoError, match="Directory mismatch"):
+        _assert_not_inside_target("my-app")
+
+
+def test_guard_passes_when_outside(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _assert_not_inside_target("my-app") 
+
+
+def test_guard_case_insensitive_on_windows(tmp_path, monkeypatch):
+    target = tmp_path / "My-App"
+    target.mkdir()
+    monkeypatch.chdir(target)
+    with patch("pygitgo.commands.new.get_platform", return_value="windows"):
+        with pytest.raises(GitGoError):
+            _assert_not_inside_target("my-app")
+
+
+def test_guard_case_sensitive_on_non_windows(tmp_path, monkeypatch):
+    target = tmp_path / "My-App"
+    target.mkdir()
+    monkeypatch.chdir(target)
+    with patch("pygitgo.commands.new.get_platform", return_value="linux"):
+        _assert_not_inside_target("my-app")
+
+
+@patch("pygitgo.commands.new.init_operation")
+@patch("pygitgo.commands.new.repo_operation")
+@patch("pygitgo.commands.new.link_core")
+@patch("os.chdir")
+@patch("pygitgo.commands.new.banner")
+@patch("pygitgo.commands.new.error")
+@patch("pygitgo.commands.new.confirm")
+def test_new_operation_link_failure(mock_confirm, mock_error, mock_banner, mock_chdir, mock_link_core, mock_repo_operation, mock_init_operation):
+    args = MagicMock()
+    args.name = "my-project"
+    args.lang = "python"
+    args.template = None
+    args.private = True
+    args.description = "my desc"
+
+    mock_repo_operation.return_value = "https://github.com/user/my-project.git"
+    mock_link_core.side_effect = GitGoError("remote link cancelled")
+    mock_confirm.return_value = False
+
+    with pytest.raises(SystemExit) as sys_exit:
+        new_operation(args)
+
+    assert sys_exit.value.code == 1
+    mock_init_operation.assert_called_once_with(args)
+    mock_chdir.assert_called_once_with("my-project")
+    mock_repo_operation.assert_called_once_with(args, silent=True)
+    mock_link_core.assert_called_once_with("https://github.com/user/my-project.git", "Initial commit", silent=True, already_initialized=True)
+    mock_banner.assert_not_called()
+    mock_error.assert_called_once_with("remote link cancelled")
+    mock_confirm.assert_called_once_with("Delete the repo I just created on GitHub? (y/n): ", destructive=True)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,5 +1,6 @@
 from pygitgo.utils.platform import get_platform
 
+
 def test_get_platform_on_windows(mocker):
     mocker.patch('platform.system', return_value='Windows')
 
@@ -59,4 +60,4 @@ def test_open_url_failure(mocker):
 
     from pygitgo.utils.platform import open_url
     open_url("https://example.com")
-    mock_warning.assert_called_once_with("Could not open browser automatically.")
+    mock_warning.assert_called_once_with("Could not open browser automatically.")

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch, MagicMock
-from pygitgo.commands.pull import pull_operation
 from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.commands.pull import pull_operation
+from unittest.mock import patch, MagicMock
 from argparse import Namespace
-import subprocess
 import pytest
+
 
 @patch("pygitgo.commands.pull.run_command")
 @patch("pygitgo.commands.pull.success")

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -15,7 +15,7 @@ def test_push_new_branch_success(mocker):
     fake_new_branch = mocker.patch("pygitgo.commands.push.git_new_branch")
     fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
     fake_push = mocker.patch("pygitgo.commands.push.git_push")
-    mocker.patch("pygitgo.commands.push.print_banner")
+    mocker.patch("pygitgo.commands.push.banner")
 
     args = Namespace(branch="feature-branch", message="Init commit", new=True, select=False)
     push_operation(args)
@@ -28,11 +28,12 @@ def test_push_new_branch_success(mocker):
 def test_push_wrong_branch_auto_switch(mocker):
     mocker.patch("pygitgo.commands.push.is_branch_exist", return_value=True)
     mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.confirm", return_value=True)
     fake_info = mocker.patch("pygitgo.commands.push.info")
     fake_jump = mocker.patch("pygitgo.commands.push.jump_operation")
     fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
     fake_push = mocker.patch("pygitgo.commands.push.git_push")
-    mocker.patch("pygitgo.commands.push.print_banner")
+    mocker.patch("pygitgo.commands.push.banner")
 
     args = Namespace(branch="feature-branch", message="Init commit", new=False, select=False)
     push_operation(args)
@@ -46,13 +47,26 @@ def test_push_wrong_branch_auto_switch(mocker):
     fake_push.assert_called_once_with("feature-branch")
 
 
+def test_push_wrong_branch_auto_switch_refused(mocker):
+    mocker.patch("pygitgo.commands.push.is_branch_exist", return_value=True)
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+    mocker.patch("pygitgo.commands.push.confirm", return_value=False)
+    fake_jump = mocker.patch("pygitgo.commands.push.jump_operation")
+
+    args = Namespace(branch="feature-branch", message="Init commit", new=False, select=False)
+    with pytest.raises(GitGoError, match="Push aborted"):
+        push_operation(args)
+
+    fake_jump.assert_not_called()
+
+
 def test_push_default_branch_and_msg(mocker):
     mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
     mocker.patch("pygitgo.commands.push.get_config", return_value="Default Msg")
     mocker.patch("pygitgo.commands.push.info")
     fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
     fake_push = mocker.patch("pygitgo.commands.push.git_push")
-    mocker.patch("pygitgo.commands.push.print_banner")
+    mocker.patch("pygitgo.commands.push.banner")
 
     args = Namespace(branch=None, message=None, new=False, select=False)
     push_operation(args)
@@ -93,13 +107,13 @@ def test_push_select_success(mocker):
     fake_stage = mocker.patch("pygitgo.commands.push.selective_stage")
     fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
     fake_push = mocker.patch("pygitgo.commands.push.git_push")
-    mocker.patch("pygitgo.commands.push.print_banner")
+    mocker.patch("pygitgo.commands.push.banner")
 
     args = Namespace(branch=None, message="Selective push", new=False, select=True)
     push_operation(args)
 
     fake_stage.assert_called_once_with(["file1.txt"])
-    fake_commit.assert_called_once_with("Selective push", loading_msg="Commiting selected files...", skip_staging=True)
+    fake_commit.assert_called_once_with("Selective push", loading_msg="Committing selected files...", skip_staging=True)
     fake_push.assert_called_once_with("main")
 
 
@@ -109,7 +123,7 @@ def test_push_clean_but_unpushed_commits(mocker):
     fake_run = mocker.patch("pygitgo.commands.push.run_command", return_value="abc1234 Unpushed commit message\n")
     fake_warning = mocker.patch("pygitgo.commands.push.warning")
     fake_push = mocker.patch("pygitgo.commands.push.git_push")
-    mocker.patch("pygitgo.commands.push.print_banner")
+    mocker.patch("pygitgo.commands.push.banner")
 
     args = Namespace(branch=None, message="Commit message", new=False, select=False)
     push_operation(args)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -4,7 +4,6 @@ from pygitgo.commands.repo import (
     _get_github_token,
     create_github_repo,
     repo_operation,
-    _clear_saved_token,
 )
 import urllib.error
 import pytest

--- a/tests/test_ssh_utils.py
+++ b/tests/test_ssh_utils.py
@@ -1,7 +1,7 @@
 from pygitgo.auth.ssh_utils import (
     ensure_github_known_host, check_connection, get_github_username,
     generate_ssh_key, convert_https_to_ssh, is_ssh_url,
-    _try_ssh_add, ensure_ssh_agent, clear_ssh_cache
+    _try_ssh_add, ensure_ssh_agent
 )
 from pygitgo.exceptions import GitGoError
 from pathlib import Path
@@ -182,5 +182,39 @@ def test_ensure_ssh_agent_linux_failure(mocker):
     fake_try.assert_called_once_with(Path("mock_key"))
     assert fake_warning.call_count == 1
     assert fake_info.call_count == 1
+
+
+def test_generate_ssh_key_exists_and_declined(mocker):
+    mocker.patch("pygitgo.auth.ssh_utils.get_ssh_key_path", return_value=Path("mock_key"))
+    mocker.patch("pathlib.Path.exists", return_value=True)
+    mocker.patch("pathlib.Path.mkdir")
+    mocker.patch("pygitgo.utils.cli_io.confirm", return_value=False)
+
+    with pytest.raises(GitGoError) as exc_info:
+        generate_ssh_key("test@example.com")
+    assert "SSH key generation aborted" in str(exc_info.value)
+
+
+def test_generate_ssh_key_exists_and_accepted(mocker):
+    mocker.patch("pygitgo.auth.ssh_utils.get_ssh_key_path", return_value=Path("mock_key"))
+    mocker.patch("pathlib.Path.exists", return_value=True)
+    mocker.patch("pathlib.Path.mkdir")
+    mocker.patch("pygitgo.utils.cli_io.confirm", return_value=True)
+    mock_remove = mocker.patch("os.remove")
+    fake_run = mocker.patch("pygitgo.auth.ssh_utils.run_command")
+
+    key_path = generate_ssh_key("test@example.com")
+    assert key_path == Path("mock_key")
+    assert mock_remove.call_count == 2
+    fake_run.assert_any_call(
+        command=[
+            "ssh-keygen",
+            "-t", "ed25519",
+            "-C", "test@example.com",
+            "-f", "mock_key",
+            "-N", ""
+        ]
+    )
+
 
 

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,8 +1,6 @@
-import pytest
-from unittest.mock import patch, MagicMock
 from pygitgo.commands.staging import get_changed_files, display_file_picker, selective_stage
-from argparse import Namespace
-import subprocess
+from unittest.mock import patch
+
 
 @patch("pygitgo.commands.staging.run_command")
 def test_get_changed_files_with_changes(mock_run_command):

--- a/tests/test_stash.py
+++ b/tests/test_stash.py
@@ -1,4 +1,3 @@
-import pytest
 from pygitgo.exceptions import GitCommandError
 from pygitgo.commands.stash import (
     git_stash_push, git_stash_pop, git_stash_apply,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -224,3 +224,86 @@ def test_load_state_keyboard_interrupt(mocker):
     fake_run.assert_called_once_with(["git", "checkout", "--", "."])
     fake_success.assert_called_once_with("Partial changes cleaned up. Your stash is still saved.")
 
+
+def _state_args(action=None, action_alias=None, identifier=None, all=False):
+    from argparse import Namespace
+    return Namespace(action=action, action_alias=action_alias, identifier=identifier, all=all)
+
+
+def test_state_operation_list(mocker):
+    from pygitgo.commands.state import state_operation
+    mock_list = mocker.patch("pygitgo.commands.state.state_list")
+
+    state_operation(_state_args(action="list"))
+
+    mock_list.assert_called_once()
+
+
+def test_state_operation_save_with_name(mocker):
+    from pygitgo.commands.state import state_operation
+    mock_save = mocker.patch("pygitgo.commands.state.save_state")
+
+    state_operation(_state_args(action="save", identifier="wip"))
+
+    mock_save.assert_called_once_with("wip")
+
+
+def test_state_operation_load_with_id(mocker):
+    from pygitgo.commands.state import state_operation
+    mock_load = mocker.patch("pygitgo.commands.state.load_state")
+
+    state_operation(_state_args(action="load", identifier="2"))
+
+    mock_load.assert_called_once_with("2")
+
+
+def test_state_operation_delete_with_id(mocker):
+    from pygitgo.commands.state import state_operation
+    mock_delete = mocker.patch("pygitgo.commands.state.delete_state")
+
+    state_operation(_state_args(action="delete", identifier="1"))
+
+    mock_delete.assert_called_once_with("1")
+
+
+def test_state_operation_alias_list(mocker):
+    from pygitgo.commands.state import state_operation
+    mock_list = mocker.patch("pygitgo.commands.state.state_list")
+
+    state_operation(_state_args(action_alias="list"))
+
+    mock_list.assert_called_once()
+
+
+def test_state_operation_delete_all_via_flag(mocker):
+    from pygitgo.commands.state import state_operation
+    mock_delete = mocker.patch("pygitgo.commands.state.delete_state")
+
+    state_operation(_state_args(action="delete", all=True))
+
+    mock_delete.assert_called_once_with("-a")
+
+
+def test_state_operation_conflicting_actions():
+    from pygitgo.commands.state import state_operation
+    from pygitgo.exceptions import GitGoError
+
+    with pytest.raises(GitGoError, match="Conflicting actions"):
+        state_operation(_state_args(action="list", action_alias="save"))
+
+
+def test_state_operation_all_flag_requires_delete():
+    from pygitgo.commands.state import state_operation
+    from pygitgo.exceptions import GitGoError
+
+    with pytest.raises(GitGoError, match="-a/--all flag is only valid"):
+        state_operation(_state_args(action="list", all=True))
+
+
+def test_state_operation_missing_action():
+    from pygitgo.commands.state import state_operation
+    from pygitgo.exceptions import GitGoError
+
+    with pytest.raises(GitGoError, match="Missing action"):
+        state_operation(_state_args())
+

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -1,8 +1,8 @@
-import pytest
-from unittest.mock import patch, MagicMock, call
 from pygitgo.commands.undo import undo_commit, undo_add, undo_changes, undo_link, undo_push, undo_operation
 from pygitgo.exceptions import GitGoError, GitCommandError
+from unittest.mock import patch
 from argparse import Namespace
+import pytest
 
 
 @patch("pygitgo.commands.undo.run_command")
@@ -47,10 +47,11 @@ def test_undo_add_failure(mock_run_command):
 
 @patch("pygitgo.commands.undo.run_command")
 @patch("pygitgo.commands.undo.success")
-@patch("pygitgo.commands.undo.input", return_value="y")
-def test_undo_changes_success(mock_input, mock_success, mock_run_command):
+@patch("pygitgo.commands.undo.confirm", return_value=True)
+@patch("pygitgo.commands.undo.banner")
+def test_undo_changes_success(mock_banner, mock_confirm, mock_success, mock_run_command):
     undo_changes()
-    mock_input.assert_called_once()
+    mock_confirm.assert_called_once()
     assert mock_run_command.call_count == 2
     mock_run_command.assert_any_call(["git", "reset", "--hard", "HEAD"], loading_msg="Throwing away edits...", ok_text="Edits discarded.")
     mock_run_command.assert_any_call(["git", "clean", "-fd"], loading_msg="Removing new files...", ok_text="Working tree reset. All changes discarded.")
@@ -59,13 +60,12 @@ def test_undo_changes_success(mock_input, mock_success, mock_run_command):
 
 @patch("pygitgo.commands.undo.run_command")
 @patch("pygitgo.commands.undo.info")
-@patch("pygitgo.commands.undo.input", return_value="n")
-def test_undo_changes_abort(mock_input, mock_info, mock_run_command):
+@patch("pygitgo.commands.undo.confirm", return_value=False)
+def test_undo_changes_abort(mock_confirm, mock_info, mock_run_command):
     undo_changes()
-    mock_input.assert_called_once()
+    mock_confirm.assert_called_once()
     mock_info.assert_called_once()
     mock_run_command.assert_not_called()
-
 
 
 @patch("pygitgo.commands.undo.run_command")
@@ -107,12 +107,12 @@ def test_undo_link_no_commit_to_reset(mock_info, mock_success, mock_run_command)
     assert mock_info.call_count == 2
 
 
-
 @patch("pygitgo.commands.undo.run_command")
 @patch("pygitgo.commands.undo.get_current_branch", return_value="main")
 @patch("pygitgo.commands.undo.success")
-@patch("pygitgo.commands.undo.input", return_value="y")
-def test_undo_push_success(mock_input, mock_success, mock_branch, mock_run_command):
+@patch("pygitgo.commands.undo.confirm", return_value=True)
+@patch("pygitgo.commands.undo.banner")
+def test_undo_push_success(mock_banner, mock_confirm, mock_success, mock_branch, mock_run_command):
     undo_push()
     mock_run_command.assert_any_call(["git", "reset", "--soft", "HEAD~"], loading_msg="Reverting last commit locally...", ok_text="Last commit reverted locally.")
     mock_run_command.assert_any_call(["git", "push", "--force", "origin", "main"], loading_msg="Force-pushing reverted state to 'main'...", ok_text="Last push reverted. Remote 'main' is back to the previous commit.")
@@ -122,8 +122,8 @@ def test_undo_push_success(mock_input, mock_success, mock_branch, mock_run_comma
 @patch("pygitgo.commands.undo.run_command")
 @patch("pygitgo.commands.undo.get_current_branch", return_value="main")
 @patch("pygitgo.commands.undo.info")
-@patch("pygitgo.commands.undo.input", return_value="n")
-def test_undo_push_abort(mock_input, mock_info, mock_branch, mock_run_command):
+@patch("pygitgo.commands.undo.confirm", return_value=False)
+def test_undo_push_abort(mock_confirm, mock_info, mock_branch, mock_run_command):
     undo_push()
     mock_run_command.assert_not_called()
     mock_info.assert_called_once_with("Canceled. Remote is unchanged.")
@@ -131,8 +131,8 @@ def test_undo_push_abort(mock_input, mock_info, mock_branch, mock_run_command):
 
 @patch("pygitgo.commands.undo.run_command")
 @patch("pygitgo.commands.undo.get_current_branch", return_value="main")
-@patch("pygitgo.commands.undo.input", return_value="y")
-def test_undo_push_no_commit(mock_input, mock_branch, mock_run_command):
+@patch("pygitgo.commands.undo.confirm", return_value=True)
+def test_undo_push_no_commit(mock_confirm, mock_branch, mock_run_command):
     mock_run_command.side_effect = GitCommandError(["git", "reset"])
     with pytest.raises(GitGoError, match="Undo failed"):
         undo_push()
@@ -140,46 +140,58 @@ def test_undo_push_no_commit(mock_input, mock_branch, mock_run_command):
 
 @patch("pygitgo.commands.undo.run_command")
 @patch("pygitgo.commands.undo.get_current_branch", return_value="main")
-@patch("pygitgo.commands.undo.input", return_value="y")
-def test_undo_push_force_push_fails(mock_input, mock_branch, mock_run_command):
+@patch("pygitgo.commands.undo.confirm", return_value=True)
+def test_undo_push_force_push_fails(mock_confirm, mock_branch, mock_run_command):
     mock_run_command.side_effect = [None, GitCommandError(["git", "push", "--force"])]
     with pytest.raises(GitGoError, match="Force-push failed"):
         undo_push()
 
 
-@patch("pygitgo.commands.undo.undo_commit")
-def test_undo_operation_commit(mock_undo_commit):
+@patch("pygitgo.commands.undo.undo_commit", return_value=True)
+@patch("pygitgo.commands.undo.banner")
+def test_undo_operation_commit(mock_banner, mock_undo_commit):
     args = Namespace(action="commit")
     undo_operation(args)
     mock_undo_commit.assert_called_once()
+    mock_banner.assert_called_once()
 
 
-@patch("pygitgo.commands.undo.undo_add")
-def test_undo_operation_add(mock_undo_add):
+@patch("pygitgo.commands.undo.undo_add", return_value=True)
+@patch("pygitgo.commands.undo.banner")
+def test_undo_operation_add(mock_banner, mock_undo_add):
     args = Namespace(action="add")
     undo_operation(args)
     mock_undo_add.assert_called_once()
+    mock_banner.assert_called_once()
 
 
-@patch("pygitgo.commands.undo.undo_changes")
-def test_undo_operation_changes(mock_undo_changes):
+@patch("pygitgo.commands.undo.undo_changes", return_value=False)
+@patch("pygitgo.commands.undo.banner")
+def test_undo_operation_changes(mock_banner, mock_undo_changes):
     args = Namespace(action="changes")
     undo_operation(args)
     mock_undo_changes.assert_called_once()
+    # banner should NOT fire when user aborts (returns False)
+    mock_banner.assert_not_called()
 
 
-@patch("pygitgo.commands.undo.undo_link")
-def test_undo_operation_link(mock_undo_link):
+@patch("pygitgo.commands.undo.undo_link", return_value=True)
+@patch("pygitgo.commands.undo.banner")
+def test_undo_operation_link(mock_banner, mock_undo_link):
     args = Namespace(action="link")
     undo_operation(args)
     mock_undo_link.assert_called_once()
+    mock_banner.assert_called_once()
 
 
-@patch("pygitgo.commands.undo.undo_push")
-def test_undo_operation_push(mock_undo_push):
+@patch("pygitgo.commands.undo.undo_push", return_value=False)
+@patch("pygitgo.commands.undo.banner")
+def test_undo_operation_push(mock_banner, mock_undo_push):
     args = Namespace(action="push")
     undo_operation(args)
     mock_undo_push.assert_called_once()
+    # banner should NOT fire when user aborts (returns False)
+    mock_banner.assert_not_called()
 
 
 def test_undo_operation_invalid():

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -1,10 +1,9 @@
 from pygitgo.utils.update_checker import (
     read_cache, write_cache, should_check, get_latest_version,
-    parse_version, check_for_updates, check_for_updates_background,
-    CACHE_FILE
+    parse_version, check_for_updates, check_for_updates_background
 )
 from datetime import datetime, timedelta
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 import json
 
 


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [x] Refactor / internal

## Changes

- Added `pygitgo.utils.cli_io` for shared prompts, banners, and severity output. `colors.py` is ANSI constants only now.
- `gitgo new`: blocks running inside a same-named folder, handles link failures without a false success banner, and can delete an orphan GitHub repo on failure.
- `gitgo link` / `confirm_remote_link`: connection failures raise `GitGoError` instead of exiting quietly.
- `gitgo push`: asks before auto-switching to an existing branch via `jump`.
- `gitgo user login`: prompts before overwriting an existing SSH key.
- `gitgo repo`: caps invalid-token retries at 3.
- `gitgo config`: invalid keys raise `GitGoError` (exit 1) instead of returning 0.
- Undo, pull, jump, init, repo: success banners and calmer copy. Fixed "Commiting" typo.
- Tests: 309 passing. New files: `test_main`, `test_executor`, `test_integration_git`, `test_cli_io`. Added state dispatcher, jump/link interrupt, and link failure coverage.

## Checklist

- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md)
- [ ] `README.md` updated (if a command was added or changed)
- [x] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)