### PR TITLE
fix: prevent terminal hang and add ssh host check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed the connection check spinner displaying the success message while it was still loading in login flow.
+- Fixed the CLI freezing on remote operations by passing DEVNULL to stdin in the command executor.
+- Fixed `gitgo link` failing on new SSH connections by adding a GitHub known host check.
 
 ---
 

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -2,6 +2,7 @@ from pygitgo.commands.git_remote import add_remote_origin, confirm_remote_link
 from pygitgo.utils.cli_io import success, warning, error, info, banner
 from pygitgo.commands.git_core import git_init, git_commit, git_push
 from pygitgo.commands.git_branch import get_current_branch
+from pygitgo.auth.ssh_utils import ensure_github_known_host
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.validators import validate_repo_url
 from pygitgo.utils.config import get_default_branch
@@ -41,6 +42,8 @@ def _link_interrupt_cleanup(repo_url, initialized, committed, remote_added):
 def link_core(repo_url, commit_message, silent=False, already_initialized=False):
     if not validate_repo_url(repo_url):
         raise GitGoError(f"Invalid remote repository URL: '{repo_url}'")
+    
+    ensure_github_known_host()
 
     initialized = False
     committed = False

--- a/src/pygitgo/utils/executor.py
+++ b/src/pygitgo/utils/executor.py
@@ -22,7 +22,8 @@ def run_command(command, return_complete=False, loading_msg=None, ok_text=None, 
             command,
             check=True,
             capture_output=True,
-            text=True
+            text=True,
+            stdin=subprocess.DEVNULL,
         )
 
         if spinner:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -11,7 +11,7 @@ def test_run_command_success(mocker):
 
     res = run_command(["echo", "hello"])
     assert res == "hello world"
-    mock_run.assert_called_once_with(["echo", "hello"], check=True, capture_output=True, text=True)
+    mock_run.assert_called_once_with(["echo", "hello"], check=True, capture_output=True, text=True, stdin=subprocess.DEVNULL)
 
 def test_run_command_success_complete(mocker):
     mock_run = mocker.patch("subprocess.run")


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal

## Changes

- `link`: added `ensure_github_known_host` check so it doesnt fail on new ssh connections.
- `executor`: set `stdin` to `DEVNULL` so the cli doesnt freeze up waiting for user input.

## Checklist

- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md)
- [ ] `README.md` updated (if a command was added or changed)
- [x] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)
