### PR TITLE
fix: CLI freezing on remote ops, link push failures, and GIT_SSH_COMMAND override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed the connection check spinner displaying the success message while it was still loading in login flow.
-- Fixed the CLI freezing on remote operations and terminal corruption by passing DEVNULL to stdin and disabling Git interactive prompts (`GIT_TERMINAL_PROMPT=0`) in the command executor.
+- Fixed the CLI freezing and terminal output corruption on remote operations by disabling Git interactive prompts (`GIT_TERMINAL_PROMPT=0`) and SSH passphrase prompts (`BatchMode=yes`) in the command executor. The existing `stdin=DEVNULL` only blocked stdin; Git bypassed it by writing directly to the terminal device.
 - Fixed `gitgo link` failing on new SSH connections by adding a GitHub known host check.
+- Fixed `gitgo link <https-url>` failing to push when the remote had existing content. HTTPS-to-SSH conversion now happens at the start of `link_core`, before `ls-remote` runs, so the remote branch check succeeds and the required `--allow-unrelated-histories` pull is performed correctly.
+- Fixed `gitgo link` crashing with a confusing push error on a completely empty local folder linked to an empty remote. The executor now checks for local commits with `git rev-parse HEAD` before attempting a push, and prints an actionable message if there is nothing to push.
+- Fixed the command executor silently overwriting a user-defined `GIT_SSH_COMMAND` environment variable. It now appends `-o BatchMode=yes` to the existing value instead of replacing it, preserving custom identity files and proxy commands.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed the connection check spinner displaying the success message while it was still loading in login flow.
-- Fixed the CLI freezing on remote operations by passing DEVNULL to stdin in the command executor.
+- Fixed the CLI freezing on remote operations and terminal corruption by passing DEVNULL to stdin and disabling Git interactive prompts (`GIT_TERMINAL_PROMPT=0`) in the command executor.
 - Fixed `gitgo link` failing on new SSH connections by adding a GitHub known host check.
 
 ---

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -2,7 +2,7 @@ from pygitgo.commands.git_remote import add_remote_origin, confirm_remote_link
 from pygitgo.utils.cli_io import success, warning, error, info, banner
 from pygitgo.commands.git_core import git_init, git_commit, git_push
 from pygitgo.commands.git_branch import get_current_branch
-from pygitgo.auth.ssh_utils import ensure_github_known_host
+from pygitgo.auth.ssh_utils import ensure_github_known_host, convert_https_to_ssh, is_ssh_url, check_connection
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.validators import validate_repo_url
 from pygitgo.utils.config import get_default_branch
@@ -44,6 +44,12 @@ def link_core(repo_url, commit_message, silent=False, already_initialized=False)
         raise GitGoError(f"Invalid remote repository URL: '{repo_url}'")
     
     ensure_github_known_host()
+
+    if not is_ssh_url(repo_url):
+        if check_connection(ok_text="GitHub connection verified.", fail_text=None):
+            ssh_url = convert_https_to_ssh(repo_url)
+            if ssh_url:
+                repo_url = ssh_url
 
     initialized = False
     committed = False
@@ -101,7 +107,16 @@ def link_core(repo_url, commit_message, silent=False, already_initialized=False)
                 warning(f"Then: gitgo push {main_branch} 'your message'\n")
                 raise GitGoError(f"Failed to merge remote content: {e.stderr}" if e.stderr else "Failed to merge remote content.")
 
-        git_push(current_branch)
+        try:
+            run_command(["git", "rev-parse", "HEAD"])
+            has_commits = True
+        except GitCommandError:
+            has_commits = False
+
+        if has_commits:
+            git_push(current_branch)
+        else:
+            info("Repository is currently empty. Add files and run 'gitgo push' to upload.")
 
         if not silent:
             banner("REPOSITORY INITIALIZED AND DEPLOYED.", "LOCAL REPOSITORY CONNECTED TO REMOTE ORIGIN.")

--- a/src/pygitgo/utils/executor.py
+++ b/src/pygitgo/utils/executor.py
@@ -20,7 +20,8 @@ def run_command(command, return_complete=False, loading_msg=None, ok_text=None, 
     try:
         env = os.environ.copy()
         env["GIT_TERMINAL_PROMPT"] = "0"
-        env["GIT_SSH_COMMAND"] = "ssh -o BatchMode=yes"
+        base_ssh_cmd = env.get("GIT_SSH_COMMAND", "ssh")
+        env["GIT_SSH_COMMAND"] = f"{base_ssh_cmd} -o BatchMode=yes"
 
         result = subprocess.run(
             command,

--- a/src/pygitgo/utils/executor.py
+++ b/src/pygitgo/utils/executor.py
@@ -18,12 +18,17 @@ def run_command(command, return_complete=False, loading_msg=None, ok_text=None, 
         spinner.start()
 
     try:
+        env = os.environ.copy()
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env["GIT_SSH_COMMAND"] = "ssh -o BatchMode=yes"
+
         result = subprocess.run(
             command,
             check=True,
             capture_output=True,
             text=True,
             stdin=subprocess.DEVNULL,
+            env=env,
         )
 
         if spinner:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -11,7 +11,7 @@ def test_run_command_success(mocker):
 
     res = run_command(["echo", "hello"])
     assert res == "hello world"
-    mock_run.assert_called_once_with(["echo", "hello"], check=True, capture_output=True, text=True, stdin=subprocess.DEVNULL)
+    mock_run.assert_called_once_with(["echo", "hello"], check=True, capture_output=True, text=True, stdin=subprocess.DEVNULL, env=mocker.ANY)
 
 def test_run_command_success_complete(mocker):
     mock_run = mocker.patch("subprocess.run")

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -38,7 +38,14 @@ def test_link_new_repo_no_remote_refs(mocker):
     mocker.patch("pygitgo.commands.link.get_default_branch", return_value="main")
     fake_push = mocker.patch("pygitgo.commands.link.git_push")
 
-    fake_run = mocker.patch("pygitgo.commands.link.run_command", return_value="")
+    fake_run = mocker.patch(
+        "pygitgo.commands.link.run_command",
+        side_effect=[
+            "",       # git branch -m main (branch rename)
+            "",       # git ls-remote (no remote refs)
+            "abc123", # git rev-parse HEAD (has local commits)
+        ]
+    )
 
     args = Namespace(url="git@github.com:user/repo.git", message="Initial commit")
     link_operation(args)
@@ -65,7 +72,8 @@ def test_link_new_repo_with_remote_refs_pull_success(mocker):
         "pygitgo.commands.link.run_command",
         side_effect=[
             "1234567890abcdef refs/heads/main",  # remote_refs check
-            "Successfully pulled"                 # git pull
+            "Successfully pulled",                # git pull
+            "123456"                              # git rev-parse HEAD
         ]
     )
 
@@ -96,7 +104,8 @@ def test_link_new_repo_with_remote_refs_pull_failure(mocker):
         "pygitgo.commands.link.run_command",
         side_effect=[
             "1234567890abcdef refs/heads/main",  # remote_refs check
-            GitCommandError(["git", "pull"])     # git pull fails
+            GitCommandError(["git", "pull"]),    # git pull fails
+            "123456"                             # git rev-parse HEAD (if reached)
         ]
     )
 
@@ -112,12 +121,14 @@ def test_link_core_already_initialized_commits_and_pushes(mocker):
     from pygitgo.commands.link import link_core
 
     mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    mocker.patch("pygitgo.commands.link.check_connection", return_value=True)
+    mocker.patch("pygitgo.commands.link.convert_https_to_ssh", return_value="git@github.com:user/repo.git")
     fake_init = mocker.patch("pygitgo.commands.link.git_init")
     fake_commit = mocker.patch("pygitgo.commands.link.git_commit", return_value=True)
     fake_add_remote = mocker.patch("pygitgo.commands.link.add_remote_origin")
     mocker.patch("pygitgo.commands.link.get_current_branch", return_value="main")
     mocker.patch("pygitgo.commands.link.get_default_branch", return_value="main")
-    mocker.patch("pygitgo.commands.link.run_command", return_value="")
+    mocker.patch("pygitgo.commands.link.run_command", return_value="123456")
     fake_push = mocker.patch("pygitgo.commands.link.git_push")
 
     link_core(
@@ -133,7 +144,7 @@ def test_link_core_already_initialized_commits_and_pushes(mocker):
         loading_msg="Creating initial commit...",
         ok_text="Initial commit created.",
     )
-    fake_add_remote.assert_called_once_with("https://github.com/user/repo.git")
+    fake_add_remote.assert_called_once_with("git@github.com:user/repo.git")
     fake_push.assert_called_once_with("main")
 
 
@@ -141,6 +152,8 @@ def test_link_keyboard_interrupt_during_commit(mocker):
     from pygitgo.commands.link import link_core
 
     mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    # Return False so no URL conversion happens; the cleanup URL stays as HTTPS.
+    mocker.patch("pygitgo.commands.link.check_connection", return_value=False)
     mocker.patch("pygitgo.commands.link.git_init", return_value=True)
     mocker.patch("pygitgo.commands.link.git_commit", side_effect=KeyboardInterrupt())
     mock_warning = mocker.patch("pygitgo.commands.link.warning")
@@ -163,6 +176,8 @@ def test_link_keyboard_interrupt_after_remote_added(mocker):
     from pygitgo.commands.link import link_core
 
     mocker.patch("pygitgo.commands.link.validate_repo_url", return_value=True)
+    # Return False so no URL conversion happens; the cleanup URL stays as HTTPS.
+    mocker.patch("pygitgo.commands.link.check_connection", return_value=False)
     mocker.patch("pygitgo.commands.link.git_init", return_value=True)
     mocker.patch("pygitgo.commands.link.git_commit", return_value=True)
     mocker.patch("pygitgo.commands.link.add_remote_origin")


### PR DESCRIPTION
<!-- If you are unsure how to fill this out, see CONTRIBUTING.md: https://github.com/Huerte/GitGo/blob/main/CONTRIBUTING.md -->
<!-- Note: These hidden comments guide you while typing. GitHub hides them automatically when you submit. -->

## Type

<!-- Put an 'x' inside the brackets: [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal

## Changes

- Fixed the CLI freezing and terminal output getting corrupted during remote operations. Git was bypassing `stdin=DEVNULL` by writing prompts directly to the terminal device, so I added `GIT_TERMINAL_PROMPT=0` and `BatchMode=yes` to fully disable interactive and SSH passphrase prompts in the command executor.
- Fixed `gitgo link <https-url>` failing to push when the remote already had content. I moved the HTTPS-to-SSH conversion to the start of `link_core`, before `ls-remote` runs, so the remote branch check works and the `--allow-unrelated-histories` pull actually happens.
- Fixed `gitgo link` crashing with a confusing push error when linking a completely empty local folder to an empty remote. The executor now checks for local commits with `git rev-parse HEAD` before pushing, and shows a clear message if there's nothing to push instead of erroring out.
- Fixed the command executor silently overwriting a user's custom `GIT_SSH_COMMAND`. It now appends `-o BatchMode=yes` to whatever value is already set instead of replacing it, so custom identity files and proxy commands still work.

## Checklist

<!-- Put an 'x' inside the brackets: [x] -->

- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md)
- [ ] `README.md` updated (if a command was added or changed)
- [x] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)