### PR TITLE
chore: update the default-message text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Default-message:** Updated the default msg from "New Project Update" to "chore: new changes applied".
+
 ---
 
 ## [1.8.3] - 2026-06-18

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ gitgo config get <key>
 | Key | Description | Default |
 |-----|-------------|---------|
 | `default-branch` | The branch used for push/link | `main` |
-| `default-message` | The commit message used for push | `New Project Update` |
+| `default-message` | The commit message used for push | `chore: new changes applied` |
 
 ### Global Flags
 

--- a/src/pygitgo/commands/push.py
+++ b/src/pygitgo/commands/push.py
@@ -98,7 +98,7 @@ def push_operation(args):
                 branch = get_current_branch()
 
         if not message:
-            message = get_config("default-message", "New Project Update")
+            message = get_config("default-message", "chore: new changes applied")
             info(f"No commit message provided. Using default: '{message}'\n")
 
         if select:


### PR DESCRIPTION
<!-- If you are unsure how to fill this out, see CONTRIBUTING.md: https://github.com/Huerte/GitGo/blob/main/CONTRIBUTING.md -->
<!-- Note: These hidden comments guide you while typing. GitHub hides them automatically when you submit. -->

## Type

<!-- Put an 'x' inside the brackets: [x] -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / internal

## Changes

- `commit-default-message`: updated default commit message from "New Project Update" to "chore: new changes applied".

## Checklist

<!-- Put an 'x' inside the brackets: [x] -->

- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md)
- [ ] `README.md` updated (if a command was added or changed)
- [ ] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)