### PR TITLE
feat: add gitgo resolve, update jump command, and fix bad error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
  
 ### Added
-- **Docs**: Added a step-by-step first contribution guide in `docs/first-contribution.md`.
-- **Docs**: Added a comprehensive troubleshooting guide in `docs/troubleshooting.md` for common environment and Git issues.
-- **Templates**: Added GitHub issue templates for bug reports, feature requests, documentation, and questions.
+- **Resolve Conflict:** Added a new command `gitgo resolve`. If you get a merge conflict, this command helps you finish it easily. It stages your fixed files and finishes the sync so you don't get stuck in the Vim editor. You can also run `gitgo resolve --abort` to cancel the conflict and go back to normal.
+- **Undo Pull:** Added `gitgo undo pull` to undo a pull. It puts your branch back to how it looked before you pulled. It does the same thing as `gitgo resolve --abort`.
+- **Docs**: Added a step-by-step guide for first time contributors in `docs/first-contribution.md`.
+- **Docs**: Added a troubleshooting guide for common git errors in `docs/troubleshooting.md`.
+- **Templates**: Added GitHub issue templates for bug reports and questions.
 
 ### Changed
-- **Default-message:** Updated the default msg from "New Project Update" to "chore: new changes applied".
+- **Jump command update:** Changed how `gitgo jump` works. It now auto-saves your changes automatically without asking. It also pulls better and warns you if git is locked or stuck.
+- **Better Error Messages:** Checked all commands and fixed 11 bad error messages. Now, if push or link fails, it tells you exactly why (like internet problem, or wrong password) instead of giving a generic error.
+- **Default-message:** Changed the default commit message from "New Project Update" to "chore: new changes applied".
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.8.3"
+version = "1.9.0"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}
@@ -45,3 +45,4 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=pygitgo --cov-report=term-missing"
+pythonpath = ["src"]

--- a/src/pygitgo/auth/account.py
+++ b/src/pygitgo/auth/account.py
@@ -41,9 +41,13 @@ def ensure_user_configure(default_email=None, default_username=None):
         set_user(default_username, default_email)
         return True
     
-    warning("\nGit user identity is not configured!")
-    info("This is required for your commits to be attributed correctly.")
-    
+    print()
+    print("  Git Identity Setup")
+    print("  " + "-" * 36)
+    warning("Git user identity is not configured.")
+    info("Needed so your commits are attributed to the right account.")
+    print()
+
     if default_username:
         new_username = default_username
         info(f"Using GitHub username: {new_username}")

--- a/src/pygitgo/auth/manager.py
+++ b/src/pygitgo/auth/manager.py
@@ -1,7 +1,7 @@
 from pygitgo.utils.cli_io import info, success, warning, error
 from pygitgo.utils.platform import get_platform
 from pygitgo.utils.executor import run_command
-from pygitgo.exceptions import GitCommandError
+from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.platform import open_url
 from . import ssh_utils
 import os
@@ -44,7 +44,12 @@ def login():
         else:
             error("Please enter a valid email address.")
 
-    key_path = ssh_utils.generate_ssh_key(email=email)
+    try:
+        key_path = ssh_utils.generate_ssh_key(email=email)
+    except GitGoError as e:
+        error(str(e))
+        return False
+
     pub_key_path = str(key_path) + ".pub"
 
     with open(pub_key_path, "r") as f:
@@ -82,21 +87,23 @@ def login():
         github_username = ssh_utils.get_github_username()
         ensure_user_configure(default_email=email, default_username=github_username)
         return True
-    
-    error("Login Failed. The SSH key may not have been added to GitHub correctly.")
-    info("Possible causes:")
-    info("  1. The key was not pasted on GitHub")
 
-    if get_platform() == "windows":
-        info("  2. SSH agent is not running — run in PowerShell (as Administrator):")
-        info("       Set-Service ssh-agent -StartupType Automatic")
-        info("       Start-Service ssh-agent")
-        info("     Then run 'gitgo user login' again.")
-    else:
-        info("  2. SSH agent is not running (try: eval $(ssh-agent) && ssh-add)")
-        
-    info("  3. Network or firewall is blocking SSH connections")
-    info("Need help? Full guide: https://github.com/Huerte/GitGo/blob/main/docs/login-guide.md")
+    raw_output, timed_out, os_error = ssh_utils._get_cached_ssh_response()
+    cause = ssh_utils.classify_connection_error(raw_output, timed_out, os_error)
+
+    error("Login failed. GitHub did not accept the SSH key.")
+    info(f"Reason: {cause}")
+
+    if get_platform() == "windows" and not timed_out:
+        info("")
+        info("If the key was added correctly but still fails, the SSH agent may not be running.")
+        info("Fix (run PowerShell as Administrator):")
+        info("  Set-Service ssh-agent -StartupType Automatic")
+        info("  Start-Service ssh-agent")
+        info("Then run 'gitgo user login' again.")
+
+    info("")
+    info("Full guide: https://github.com/Huerte/GitGo/blob/main/docs/login-guide.md")
     return False
 
  

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -48,9 +48,12 @@ def _get_github_ssh_response():
             capture_output=True, text=True,
             timeout=SSH_TIMEOUT_SECONDS, stdin=subprocess.DEVNULL,
         )
-        return (result.stderr or "") + (result.stdout or "")
-    except (subprocess.TimeoutExpired, OSError):
-        return None
+        combined = (result.stderr or "") + (result.stdout or "")
+        return combined, False, None
+    except subprocess.TimeoutExpired:
+        return "", True, None
+    except OSError as e:
+        return "", False, str(e)
 
 
 def _get_cached_ssh_response():
@@ -58,7 +61,7 @@ def _get_cached_ssh_response():
     if not _cache_populated:
         _cached_ssh_response = _get_github_ssh_response()
         _cache_populated = True
-    return _cached_ssh_response
+    return _cached_ssh_response  # (raw_output, timed_out, os_error)
 
 
 def clear_ssh_cache():
@@ -67,10 +70,30 @@ def clear_ssh_cache():
     _cache_populated = False
 
 
+def classify_connection_error(raw_output: str, timed_out: bool, os_error: str | None) -> str:
+    """Return a specific, human-readable cause string based on the SSH response."""
+    if timed_out:
+        return "Connection timed out. GitHub SSH port (22) may be blocked by your network or firewall."
+    if os_error:
+        return f"Could not launch the SSH client: {os_error}"
+    if not raw_output:
+        return "No response from GitHub. Check your internet connection."
+    if "Permission denied" in raw_output:
+        return "Permission denied. The SSH key has not been added to your GitHub account, or it was added incorrectly."
+    if "Connection refused" in raw_output:
+        return "Connection refused on port 22. Try a network without strict firewall rules."
+    if "Host key verification failed" in raw_output:
+        return "Host key verification failed. Run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts"
+    if "Could not resolve hostname" in raw_output:
+        return "DNS lookup failed. You may be offline or behind a restrictive proxy."
+    # Return the raw SSH message so users see the actual problem.
+    return raw_output.strip() or "Unknown SSH error."
+
+
 def check_connection(ok_text=None, fail_text=None):
     from yaspin import yaspin
     import sys
-    
+
     ensure_github_known_host()
 
     kwargs = {"text": "Verifying GitHub connection..."}
@@ -79,8 +102,8 @@ def check_connection(ok_text=None, fail_text=None):
     spinner = yaspin(**kwargs)
     spinner.start()
 
-    output = _get_cached_ssh_response()
-    connected = output is not None and "successfully authenticated" in output
+    raw_output, timed_out, os_error = _get_cached_ssh_response()
+    connected = not timed_out and not os_error and "successfully authenticated" in raw_output
 
     if connected:
         spinner.text = ok_text or "GitHub connection verified."
@@ -93,10 +116,10 @@ def check_connection(ok_text=None, fail_text=None):
 
 
 def get_github_username():
-    output = _get_cached_ssh_response()
-    if output and "Hi " in output and "!" in output:
+    raw_output, _timed_out, _os_error = _get_cached_ssh_response()
+    if raw_output and "Hi " in raw_output and "!" in raw_output:
         try:
-            return output.split("Hi ")[1].split("!")[0]
+            return raw_output.split("Hi ")[1].split("!")[0]
         except (IndexError, ValueError):
             pass
     return None

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -69,8 +69,8 @@ def clear_ssh_cache():
     _cached_ssh_response = None
     _cache_populated = False
 
-
-def classify_connection_error(raw_output: str, timed_out: bool, os_error: str | None) -> str:
+from typing import Optional
+def classify_connection_error(raw_output: str, timed_out: bool, os_error: Optional[str]) -> str:
     """Return a specific, human-readable cause string based on the SSH response."""
     if timed_out:
         return "Connection timed out. GitHub SSH port (22) may be blocked by your network or firewall."

--- a/src/pygitgo/commands/git_branch.py
+++ b/src/pygitgo/commands/git_branch.py
@@ -5,10 +5,23 @@ from pygitgo.utils.config import get_config
 from argparse import Namespace
 
 
-def get_current_branch():
+def get_current_branch(safe=False):
     branch = run_command(["git", "branch", "--show-current"]).strip()
     if not branch:
-        branch = run_command(["git", "rev-parse", "--short", "HEAD"]).strip()
+        # We are in a detached HEAD state.
+        commit_hash = run_command(["git", "rev-parse", "--short", "HEAD"]).strip()
+        
+        if safe:
+            warning("You are in a 'detached HEAD' state (not on any branch).")
+            warning("If you switch away now, your current commits could be lost.")
+            if confirm("Would you like to create a new branch here to save your work? (y/n): "):
+                new_branch = input("Enter a name for the new branch: ").strip()
+                if new_branch:
+                    run_command(["git", "checkout", "-b", new_branch])
+                    return new_branch
+            raise GitGoError("Operation aborted to prevent data loss in detached HEAD state.")
+            
+        return commit_hash
     return branch
 
 

--- a/src/pygitgo/commands/git_branch.py
+++ b/src/pygitgo/commands/git_branch.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import success, error, info, confirm
+from pygitgo.utils.cli_io import warning, error, info, confirm
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
 from pygitgo.utils.config import get_config

--- a/src/pygitgo/commands/git_core.py
+++ b/src/pygitgo/commands/git_core.py
@@ -26,8 +26,11 @@ def git_commit(commit_message, loading_msg="Committing changes...", skip_staging
         status_result = run_command(["git", "status", "--porcelain"])
         if not status_result.strip():
             return False
-    except GitCommandError:
-        return False
+    except GitCommandError as e:
+        stderr = getattr(e, "stderr", str(e))
+        if "not a git repository" in stderr.lower():
+            raise GitGoError("Not inside a git repository. Run 'gitgo init' or 'gitgo link' first.")
+        raise GitGoError(f"Could not check repository status: {stderr}")
     
     sanitize_signing_config()
 
@@ -78,8 +81,81 @@ def git_push(branch, ok_text=None):
     try:
         run_command(["git", "push", "-u", "origin", branch], loading_msg=f"Pushing to remote branch '{branch}'...", ok_text=ok_text, err_text="Push failed: verify your remote URL and SSH key, then try again.")
     except (GitCommandError, OSError) as e:
-        info("Run:  git remote -v   to inspect your current remote.")
-        if "rebase in progress" in str(e):
+        stderr = getattr(e, "stderr", str(e))
+        if "rebase in progress" in stderr.lower():
             handle_rebase()
+        elif "non-fast-forward" in stderr.lower() or "rejected" in stderr.lower():
+            info("The remote has commits you don't have locally.")
+            info("Run 'gitgo pull' first, then push again.")
+            raise GitGoError("Push rejected: pull the latest changes first.")
+        elif "repository not found" in stderr.lower() or "does not exist" in stderr.lower():
+            info("Run:  git remote -v   to verify the remote URL.")
+            raise GitGoError("Push failed: remote repository not found.")
+        elif "permission denied" in stderr.lower():
+            info("Check that your SSH key is added to GitHub.")
+            info("Run:  gitgo user login   to re-authenticate.")
+            raise GitGoError("Push failed: permission denied.")
         else:
-            raise GitGoError("Push failed - see above.")
+            info("Run:  git remote -v   to inspect your current remote.")
+            raise GitGoError(f"Push failed: {stderr}" if stderr else "Push failed — check the output above.")
+
+
+def abort_pull_conflict():
+    from pathlib import Path
+    from pygitgo.utils.cli_io import warning, info, confirm
+    from pygitgo.exceptions import GitCommandError, GitGoError
+    from pygitgo.utils.executor import run_command
+    from pygitgo.commands.git_branch import get_current_branch
+    
+    rebase_in_progress = Path(".git/rebase-merge").exists() or Path(".git/rebase-apply").exists()
+    
+    if rebase_in_progress:
+        warning("A sync or jump hit a merge conflict and is paused.")
+        if not confirm("Cancel the sync and discard any conflict fixes? (y/n): ", destructive=True):
+            info("Canceled. The conflict is still active.")
+            return False
+            
+        try:
+            run_command(["git", "rebase", "--abort"], loading_msg="Aborting sync...", ok_text="Sync aborted. Branch is back to how it was before the conflict.")
+            return True
+        except GitCommandError as e:
+            raise GitGoError(f"Abort failed: {getattr(e, 'stderr', str(e))}")
+
+    try:
+        run_command(["git", "rev-parse", "ORIG_HEAD"])
+    except GitCommandError:
+        raise GitGoError(
+            "No pull to undo. ORIG_HEAD not found — this means no pull has been run yet."
+        )
+
+    try:
+        branch = get_current_branch(safe=True)
+    except GitCommandError as e:
+        raise GitGoError(f"Could not determine the current branch: {e}")
+
+    warning("This will reset your branch to the state before the last pull.")
+    warning("Any commits that arrived in the pull will be removed locally.")
+    if not confirm("Undo the last pull? Type 'y' to confirm: ", destructive=True):
+        info("Canceled. Branch is unchanged.")
+        return False
+
+    try:
+        run_command(
+            ["git", "reset", "--hard", "ORIG_HEAD"],
+            loading_msg="Reverting to pre-pull state...",
+            ok_text="Branch reset to its state before the last pull."
+        )
+    except GitCommandError as e:
+        raise GitGoError(f"Undo failed: {getattr(e, 'stderr', str(e))}")
+
+    try:
+        behind = run_command(["git", "rev-list", "--count", f"HEAD..origin/{branch}"]).strip()
+        if behind and int(behind) > 0:
+            warning(f"Your local branch is now {behind} commit(s) behind remote '{branch}'.")
+            info("The remote still has the pulled commits. Your local copy has been reset.")
+            info(f"To push your undo to the remote: git push --force origin {branch}")
+            info("Only do this if you are the only person working on this branch.")
+    except (GitCommandError, ValueError):
+        pass
+
+    return True

--- a/src/pygitgo/commands/git_remote.py
+++ b/src/pygitgo/commands/git_remote.py
@@ -20,9 +20,17 @@ def confirm_remote_link(ok_text=None):
     try:
         run_command(["git", "ls-remote", "origin"], loading_msg="Testing connection to remote...", ok_text=ok_text)
         return True
-    except GitCommandError:
+    except GitCommandError as e:
+        stderr = getattr(e, "stderr", str(e))
         info("Run:  git remote -v   to inspect your current remote.")
-        raise GitGoError("Connection failed — verify the URL and your SSH key.")
+        if "could not resolve" in stderr.lower():
+            raise GitGoError("Connection failed: DNS lookup failed for the remote host. Check your internet.")
+        elif "permission denied" in stderr.lower():
+            raise GitGoError("Connection failed: SSH key not accepted. Run 'gitgo user login' to re-authenticate.")
+        elif stderr:
+            raise GitGoError(f"Connection failed: {stderr}")
+        else:
+            raise GitGoError("Connection failed — verify the URL and your SSH key.")
 
 
 def check_and_sync_branch(branch):
@@ -56,6 +64,6 @@ def handle_rebase():
     warning("Conflict detected during rebase.")
     info("Resolve conflicts manually, then run:")
     info("    git add <files>")
-    info("    git rebase --continue")
+    info("    gitgo resolve")
     info("When finished, run 'gitgo push <branch> <message>' again.")
     raise GitGoError("Push aborted — rebase conflict in progress.")

--- a/src/pygitgo/commands/init.py
+++ b/src/pygitgo/commands/init.py
@@ -1,6 +1,6 @@
 from pygitgo.commands.git_core import git_init
 from pygitgo.exceptions import GitGoError
-from pygitgo.utils.cli_io import info
+from pygitgo.utils.cli_io import info, warning
 import urllib.request
 import urllib.error
 import zipfile
@@ -320,8 +320,9 @@ def init_operation(args, standalone=False):
         if os.path.exists(target_dir) and not os.listdir(target_dir):
             try:
                 os.rmdir(target_dir)
-            except Exception:
-                pass
+            except Exception as cleanup_err:
+                warning(f"Could not remove empty folder '{target_dir}': {cleanup_err}")
+                warning(f"Delete it manually before running this command again.")
         raise e
     finally:
         os.chdir(orig_cwd)

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -59,92 +59,101 @@ def _jump_interrupt_cleanup(original_branch, stashed_code, created_branch):
 
 def jump_operation(args):
     target_branch = args.branch
-    original_branch = get_current_branch()
+    original_branch = get_current_branch(safe=True)
 
     if original_branch == target_branch:
         warning(f"Already on branch '{target_branch}'.")
         return
 
     try:
-        has_changes = run_command(['git', 'status', '--porcelain'], loading_msg="Checking for uncommitted changes...")
-    except GitCommandError:
-        raise GitGoError("Unable to check for uncommitted changes — make sure you're in a valid git repository.")
+        has_changes = run_command(["git", "status", "--porcelain"], loading_msg="Checking for local changes...")
+    except GitCommandError as e:
+        stderr = getattr(e, "stderr", str(e))
+        if "not a git repository" in stderr.lower():
+            raise GitGoError("Not inside a git repository. Run 'gitgo init' or 'gitgo link' first.")
+        raise GitGoError(f"Could not check repository status: {stderr}")
 
     stashed_code = False
     created_branch = None
 
     try:
         if has_changes.strip():
-            print()
-            info("You have unsaved changes in this folder.")
-            if not confirm(f"Move your unsaved edits to branch '{target_branch}'? (y/n): "):
-                print()
-                warning("You cannot switch branches with unsaved edits. Jump canceled.")
-                return
-            stash_result = git_stash_push(label="GitGo Jump Auto-Stash", loading_msg="Saving your changes before jumping...")
+            stash_result = git_stash_push(label="GitGo Jump Auto-Stash", loading_msg="Auto-saving local changes before switching...")
             if not stash_result:
-                warning("Stash failed. Your working tree may have untracked files.")
-                info("Run:  git status   to see what's blocking the stash.")
-                raise GitGoError("Jump aborted: could not save working changes.")
-            info("Changes saved. Jumping to the new branch...")
+                from pathlib import Path
+                lock_file = Path(".git/index.lock")
+                if lock_file.exists():
+                    warning("A stale lock file is blocking git.")
+                    info(f"Delete this file and try again: {lock_file.absolute()}")
+                elif Path(".git/rebase-merge").exists() or Path(".git/rebase-apply").exists():
+                    warning("A rebase is in progress. Finish or abort it first.")
+                    info("Abort with:  gitgo resolve --abort")
+                else:
+                    warning("Could not auto-save changes before switching.")
+                    info("Run:  git status   to see what is blocking the stash.")
+                raise GitGoError("Jump aborted: could not save local changes.")
             stashed_code = True
 
         if not is_branch_exist(target_branch):
             print()
             warning(f"Branch '{target_branch}' does not exist.")
-            if not confirm(f"Branch '{target_branch}' does not exist yet. Create it and switch to it? (y/n): "):
-                info("Exiting without jumping...")
+            if not confirm(f"Create '{target_branch}' and switch to it? (y/n): "):
+                info("Jump canceled.")
                 if stashed_code:
-                    pop_result = git_stash_pop(loading_msg="Putting your unsaved changes back...")
+                    pop_result = git_stash_pop(loading_msg="Restoring your local changes...")
                     if not pop_result:
-                        warning("Could not restore your unsaved changes automatically. Run 'gitgo state list' to recover them.")
+                        warning("Could not restore changes automatically. Run 'gitgo state list' to recover them.")
                 return
 
             ok_text = f"Branch '{target_branch}' created." if stashed_code else f"On '{target_branch}'."
             git_new_branch(target_branch, ok_text=ok_text)
             created_branch = target_branch
         else:
-            if stashed_code:
-                run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...", ok_text=f"Moved to branch '{target_branch}'.")
-                main_branch = get_main_branch()
-                try:
-                    run_command(['git', 'pull', 'origin', main_branch], loading_msg=f"Downloading the latest updates from '{main_branch}'...", ok_text=f"Downloaded updates from '{main_branch}'.")
-                except GitCommandError:
-                    warning(f"Failed to pull updates from '{main_branch}'. No internet, or the remote branch doesn't exist yet.")
-                    info(f"On '{target_branch}', but without the latest updates from '{main_branch}'.")
-            else:
-                run_command(['git', 'checkout', target_branch], loading_msg=f"Moving you to branch '{target_branch}'...", ok_text=f"Moved to branch '{target_branch}'.")
-                main_branch = get_main_branch()
-                try:
-                    run_command(['git', 'pull', 'origin', main_branch], loading_msg=f"Downloading the latest updates from '{main_branch}'...", ok_text=f"On '{target_branch}'. Up to date with '{main_branch}'.")
-                except GitCommandError:
-                    warning(f"Failed to pull updates from '{main_branch}'. No internet, or the remote branch doesn't exist yet.")
-                    info(f"On '{target_branch}', but without the latest updates from '{main_branch}'.")
+            run_command(
+                ["git", "checkout", target_branch],
+                loading_msg=f"Switching to '{target_branch}'...",
+                ok_text=f"Switched to '{target_branch}'."
+            )
+            main_branch = get_main_branch()
+            try:
+                run_command(
+                    ["git", "pull", "--rebase", "--autostash", "origin", main_branch],
+                    loading_msg=f"Syncing '{target_branch}' with latest from '{main_branch}'...",
+                    ok_text=f"'{target_branch}' is up to date with '{main_branch}'."
+                )
+            except GitCommandError as e:
+                stderr = getattr(e, "stderr", str(e))
+                if "conflict" in stderr.lower() or "rebase in progress" in stderr.lower():
+                    warning(f"Sync from '{main_branch}' hit a conflict.")
+                    info("Fix the conflict files, then run:  gitgo resolve")
+                    info("Or cancel the jump with:  gitgo resolve --abort")
+                else:
+                    warning(f"Could not sync from '{main_branch}': no remote or no internet.")
+                    info(f"On '{target_branch}', but not yet synced with '{main_branch}'.")
 
         if stashed_code:
-            apply_result = git_stash_apply(loading_msg="Unpacking your unsaved changes...")
+            apply_result = git_stash_apply(loading_msg="Restoring your local changes...")
             if not apply_result:
                 print()
-                error("MERGE CONFLICT — your changes clash with the target branch.")
+                error("CONFLICT: Your local changes clash with the target branch.")
                 print()
                 info("Option [Y]: Stay here and fix the conflict lines in your files.")
                 info("Option [N]: Undo the switch and go back to where you started.")
                 print()
-                if not confirm("Fix the conflicts yourself? (y = stay and fix / n = go back): "):
+                if not confirm("Fix the conflicts yourself? (y = stay / n = go back): "):
                     undo_jump_operation(original_branch, stashed_code, created_branch)
                     return
                 else:
                     print()
-                    success(f"On '{target_branch}'. Conflict markers are in your files.")
-                    warning("Open your editor and fix the conflict lines.")
-                    info("Your stash backup is still saved. Run 'gitgo state list' to see it.")
+                    success(f"On '{target_branch}'. Fix the conflict markers in your files.")
+                    warning("Your stash backup is still saved. Run 'gitgo state list' to see it.")
                     return
             else:
-                drop_result = git_stash_drop(loading_msg="Cleaning up the temporary stash...", ok_text=f"On '{target_branch}'. Your changes came with you.")
+                drop_result = git_stash_drop(loading_msg="Cleaning up temporary stash...", ok_text=f"On '{target_branch}'. Your changes came with you.")
                 if not drop_result:
                     warning("Could not clean up the temporary stash. Run 'gitgo state list' to remove it manually.")
 
-        if not getattr(args, 'nested', False):
+        if not getattr(args, "nested", False):
             banner("WORKSPACE RE-POSITIONED. TARGET DEPLOYMENT SECURED.", "ON TARGET BRANCH WITH RE-APPLIED STATE.")
         return
 
@@ -153,3 +162,4 @@ def jump_operation(args):
         warning("Jump interrupted (Ctrl+C).")
         _jump_interrupt_cleanup(original_branch, stashed_code, created_branch)
         sys.exit(130)
+

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -46,10 +46,16 @@ def link_core(repo_url, commit_message, silent=False, already_initialized=False)
     ensure_github_known_host()
 
     if not is_ssh_url(repo_url):
-        if check_connection(ok_text="GitHub connection verified.", fail_text=None):
+        ssh_ok = check_connection(
+            ok_text="GitHub SSH verified. Switching to SSH URL.",
+            fail_text="SSH unavailable. Keeping HTTPS URL."
+        )
+        if ssh_ok:
             ssh_url = convert_https_to_ssh(repo_url)
             if ssh_url:
                 repo_url = ssh_url
+        else:
+            warning("SSH check failed. Using HTTPS — you may be prompted for credentials on push.")
 
     initialized = False
     committed = False
@@ -81,7 +87,7 @@ def link_core(repo_url, commit_message, silent=False, already_initialized=False)
         remote_added = True
 
         try:
-            current_branch = get_current_branch()
+            current_branch = get_current_branch(safe=True)
         except GitCommandError as e:
             raise GitGoError(f"Could not determine the current branch: {e}")
 

--- a/src/pygitgo/commands/pull.py
+++ b/src/pygitgo/commands/pull.py
@@ -35,7 +35,7 @@ def pull_operation(args):
     branch = args.branch
 
     if not branch:
-        branch = get_current_branch()
+        branch = get_current_branch(safe=True)
         info(f"No branch provided. Pulling latest updates for '{branch}'...")
 
     try:
@@ -74,7 +74,10 @@ def pull_operation(args):
             info("1. Open your code editor.")
             info("2. Fix the conflict lines in your files.")
             info("3. Save the files.")
-            info("4. Run:  git rebase --continue")
+            info("4. Run:  gitgo resolve")
+            print()
+            info("Or, to cancel the pull and go back to how things were:")
+            info("Run:  gitgo resolve --abort")
             print()
             raise GitGoError("Pull failed — resolve conflicts to continue.")
         else:

--- a/src/pygitgo/commands/push.py
+++ b/src/pygitgo/commands/push.py
@@ -63,7 +63,7 @@ def push_operation(args):
     message = args.message
     select = args.select if hasattr(args, 'select') else False
 
-    original_branch = get_current_branch()
+    original_branch = get_current_branch(safe=True)
     try:
         original_head = run_command(["git", "rev-parse", "HEAD"]).strip()
     except GitCommandError:
@@ -137,9 +137,13 @@ def push_operation(args):
                         info("\nWorking tree is clean and everything is up to date.")
                         warning("Make some changes first before using GitGo to commit and push.")
                         return
-                except (GitCommandError, Exception):
-                    warning("\nNo changes to commit. Cannot verify remote status.")
-                    warning("Make some changes first or check your git remote configuration.")
+                except GitCommandError as e:
+                    stderr = getattr(e, "stderr", str(e))
+                    if "unknown revision" in stderr or "bad revision" in stderr:
+                        warning("\nBranch has no upstream yet. Push first to set it: 'gitgo push'.")
+                    else:
+                        warning(f"\nCould not verify remote status: {stderr or 'unknown error'}")
+                        info("Check your remote with:  git remote -v")
                     return
 
         banner("MISSION COMPLETE. ALL TARGETS COMMITTED AND PUSHED.", "REMOTE TARGETS ALIGNED WITH LOCAL EDITS.")

--- a/src/pygitgo/commands/repo.py
+++ b/src/pygitgo/commands/repo.py
@@ -180,7 +180,23 @@ def delete_github_repo(full_name, token=None):
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             return True
+    except urllib.error.HTTPError as e:
+        if e.code == 403:
+            raise GitGoError(
+                "Delete failed: your token does not have 'delete_repo' scope. "
+                "Generate a new token at https://github.com/settings/tokens with that scope."
+            )
+        elif e.code == 404:
+            raise GitGoError(f"Delete failed: repository '{full_name}' not found on GitHub.")
+        body = e.read().decode("utf-8", errors="replace")
+        try:
+            msg = json.loads(body).get("message", body)
+        except Exception:
+            msg = body
+        raise GitGoError(f"GitHub API error {e.code} while deleting repo: {msg}")
+    except urllib.error.URLError as e:
+        raise GitGoError(f"Network error deleting repo: {e.reason}")
     except Exception as e:
-        raise GitGoError(f"Failed to delete repository from GitHub: {str(e)}")
+        raise GitGoError(f"Unexpected error deleting repo: {e}")
 
 

--- a/src/pygitgo/commands/resolve.py
+++ b/src/pygitgo/commands/resolve.py
@@ -1,0 +1,54 @@
+from pygitgo.utils.cli_io import info, warning, error, banner
+from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.utils.executor import run_command
+from pygitgo.commands.git_core import abort_pull_conflict
+from pathlib import Path
+import os
+import subprocess
+from yaspin import yaspin
+
+def resolve_operation(args):
+    if getattr(args, 'abort', False):
+        abort_pull_conflict()
+        return
+
+    rebase_in_progress = Path(".git/rebase-merge").exists() or Path(".git/rebase-apply").exists()
+    if not rebase_in_progress:
+        raise GitGoError("No conflict resolution is currently in progress. You are good to go!")
+        
+    try:
+        run_command(["git", "status", "--porcelain"])
+    except GitCommandError:
+        raise GitGoError("Not inside a git repository.")
+        
+    # Stage the resolved files
+    run_command(["git", "add", "."], loading_msg="Staging resolved files...", ok_text="Conflict fixes staged.")
+    
+    spinner = yaspin(text="Finishing sync...", color="cyan")
+    spinner.start()
+    
+    # We use subprocess directly here to inject GIT_EDITOR=true. 
+    # This completely bypasses Vim/Nano so the user doesn't get trapped 
+    # in an editor trying to write a merge commit message.
+    env_copy = os.environ.copy()
+    env_copy["GIT_EDITOR"] = "true"
+    
+    result = subprocess.run(
+        ["git", "rebase", "--continue"],
+        capture_output=True,
+        text=True,
+        env=env_copy
+    )
+    
+    if result.returncode != 0:
+        spinner.fail("✖")
+        stderr = result.stderr.strip() or result.stdout.strip()
+        if "must edit all merge conflicts" in stderr.lower() or "still have unmerged paths" in stderr.lower():
+            raise GitGoError(
+                "You still have unresolved conflicts.\n"
+                "Open your editor, fix all the conflict markers, save, and then run 'gitgo resolve' again."
+            )
+        raise GitGoError(f"Resolve failed: {stderr}")
+        
+    spinner.ok("✔")
+    banner("CONFLICT RESOLVED. SYNC COMPLETE.", "YOUR CHANGES AND REMOTE CHANGES ARE MERGED.")

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -127,8 +127,11 @@ def load_state(state_id=None):
     try:
         apply_result = git_stash_apply(stash_id=str(selected_state["stash_index"]))
         if not apply_result:
-            error(f"Failed to load state. There may be a conflict with your current changes.")
-            raise GitGoError("Load failed — resolve conflicts first.")
+            error("Failed to restore this state.")
+            info("Your current working tree may have conflicting or uncommitted changes.")
+            info("Run 'git status' to see the current state of your files.")
+            info("Your stash entries are still safe. Run 'gitgo state list' to see them.")
+            raise GitGoError("State load failed — resolve any conflicts first, then try again.")
         success(f"State '{selected_state['message']}' restored.")
         banner("WORKSPACE SNAPSHOT RESTORED.", "SECURE VAULT WORKSPACE RE-APPLIED TO TREE.")
 

--- a/src/pygitgo/commands/undo.py
+++ b/src/pygitgo/commands/undo.py
@@ -8,10 +8,11 @@ import sys
 def undo_commit():
     try:
         run_command(["git", "reset", "--soft", "HEAD~"], loading_msg="Undoing last commit...", ok_text="Last commit undone. Files are untouched.")
-    except GitCommandError as e:
-        raise GitGoError(
-            f"Undo failed — no previous commit to revert. Details: {e}"
-        )
+    except GitCommandError:
+        try:
+            run_command(["git", "update-ref", "-d", "HEAD"], loading_msg="Undoing initial commit...", ok_text="Initial commit undone. Files are back to staged.")
+        except GitCommandError as e:
+            raise GitGoError(f"Undo failed. Details: {e}")
     return True
 
 
@@ -63,9 +64,14 @@ def undo_link():
     return True
 
 
+def undo_pull():
+    from pygitgo.commands.git_core import abort_pull_conflict
+    return abort_pull_conflict()
+
+
 def undo_push():
     try:
-        branch = get_current_branch()
+        branch = get_current_branch(safe=True)
     except GitCommandError as e:
         raise GitGoError(f"Could not determine the current branch: {e}")
 
@@ -110,8 +116,10 @@ def undo_operation(args):
         success_flag = undo_link()
     elif action == "push":
         success_flag = undo_push()
+    elif action == "pull":
+        success_flag = undo_pull()
     else:
         raise GitGoError(f"Unknown undo operation: {action}")
 
     if success_flag:
-        banner("ACTION ROLLBACK. WORKSPACE RESTORED.", "PREVIOUS STATE RE-ESTABLISHED SUCCESSFULLY.")
+        banner("ACTION ROLLBACK. WORKSPACE RESTORED.", "PREVIOUS STATE RE-ESTABLISHED SUCCESSFULLY.")

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -12,6 +12,7 @@ from pygitgo.commands.user import user_operation
 from pygitgo.commands.repo import repo_operation
 from pygitgo.commands.init import init_operation
 from pygitgo.commands.new import new_operation
+from pygitgo.commands.continue_sync import continue_operation
 from pygitgo.exceptions import GitGoError
 import argparse
 import sys
@@ -128,14 +129,15 @@ def main():
             "  gitgo undo add          Undo 'git add' (files are no longer ready to commit)\n"
             "  gitgo undo changes      DANGER: Throw away all new changes and start fresh\n"
             "  gitgo undo link         Remove the remote and undo the initial commit\n"
-            "  gitgo undo push         DANGER: Revert the last push with a force-push"
+            "  gitgo undo push         DANGER: Revert the last push with a force-push\n"
+            "  gitgo undo pull         Revert the branch to its state before the last pull"
         ), 
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     undo_parser.add_argument(
         "action", 
-        choices=["commit", "add", "changes", "link", "push"], 
-        help="What to undo: 'commit', 'add', 'changes', 'link', or 'push'"
+        choices=["commit", "add", "changes", "link", "push", "pull"], 
+        help="What to undo: 'commit', 'add', 'changes', 'link', 'push', or 'pull'"
     )
 
     pull_parser = subparsers.add_parser("pull", 
@@ -148,6 +150,12 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     pull_parser.add_argument("branch", nargs="?", default=None, help="The branch to pull from (default is your current branch)")
+
+    resolve_parser = subparsers.add_parser("resolve", 
+        help="Resolve a paused sync after fixing a merge conflict",
+        description="Automatically stages your resolved files and finishes the active merge conflict, bypassing the text editor."
+    )
+    resolve_parser.add_argument("--abort", action="store_true", help="Abort the current merge/rebase and revert to the pre-pull state")
 
     init_parser = subparsers.add_parser(
         "init",
@@ -283,6 +291,8 @@ def main():
             state_operation(args)
         elif args.command == "user":
             user_operation(args)
+        elif args.command == "resolve":
+            resolve_operation(args)
         elif args.command == "config":
             config_operation(args)
         elif args.command == "undo":
@@ -302,6 +312,10 @@ def main():
         print()
         warning("Operation canceled.")
         sys.exit(130)
+    except Exception as e:
+        error(f"Unexpected error ({type(e).__name__}): {e}")
+        info("If this keeps happening, report it: https://github.com/Huerte/GitGo/issues")
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -12,7 +12,7 @@ from pygitgo.commands.user import user_operation
 from pygitgo.commands.repo import repo_operation
 from pygitgo.commands.init import init_operation
 from pygitgo.commands.new import new_operation
-from pygitgo.commands.continue_sync import continue_operation
+from pygitgo.commands.resolve import resolve_operation
 from pygitgo.exceptions import GitGoError
 import argparse
 import sys

--- a/src/pygitgo/utils/executor.py
+++ b/src/pygitgo/utils/executor.py
@@ -51,7 +51,14 @@ def run_command(command, return_complete=False, loading_msg=None, ok_text=None, 
             stderr = e.stderr.strip() if e.stderr else ""
             returncode = e.returncode
         else:
-            stderr = f"Command not found or execution failed: {str(e)}"
+            cmd_name = command[0] if isinstance(command, list) else str(command).split()[0]
+            if "cannot find the file" in str(e) or "No such file or directory" in str(e):
+                stderr = (
+                    f"'{cmd_name}' is not installed or not on your PATH. "
+                    "Install it and make sure it is accessible from your terminal."
+                )
+            else:
+                stderr = f"Failed to run '{cmd_name}': {e}"
 
         if "detected dubious ownership" in stderr:
             danger("Git blocked this folder for security reasons (dubious ownership).")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
-from pygitgo.exceptions import GitGoError
-from pathlib import Path
-import pytest
 import sys
-
+from pathlib import Path
 
 src_dir = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(src_dir))
+
+import pytest
+from pygitgo.exceptions import GitGoError
 
 
 def capture_system_exit_code(function):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -54,7 +54,7 @@ def test_run_command_os_error(mocker):
         run_command(["cmd"])
     
     assert exc_info.value.returncode == 1
-    assert "Command not found or execution failed" in exc_info.value.stderr
+    assert "Failed to run 'cmd': file not found" in exc_info.value.stderr
 
 def test_run_command_dubious_ownership_confirm(mocker):
     mock_run = mocker.patch("subprocess.run")

--- a/tests/test_git_core.py
+++ b/tests/test_git_core.py
@@ -173,3 +173,28 @@ def test_git_commit_default_runs_git_add(mocker):
     git_commit("my message")
     add_call = fake_run.call_args_list[1][0][0]
     assert add_call == ["git", "add", "."]
+
+
+def test_abort_pull_conflict_active_rebase(mocker):
+    mocker.patch("pathlib.Path.exists", return_value=True)
+    mocker.patch("pygitgo.utils.cli_io.confirm", return_value=True)
+    fake_run = mocker.patch("pygitgo.utils.executor.run_command")
+    
+    from pygitgo.commands.git_core import abort_pull_conflict
+    result = abort_pull_conflict()
+    
+    assert result is True
+    fake_run.assert_called_once_with(["git", "rebase", "--abort"], loading_msg="Aborting sync...", ok_text="Sync aborted. Branch is back to how it was before the conflict.")
+
+
+def test_abort_pull_conflict_no_rebase(mocker):
+    mocker.patch("pathlib.Path.exists", return_value=False)
+    mocker.patch("pygitgo.utils.cli_io.confirm", return_value=True)
+    mocker.patch("pygitgo.commands.git_branch.get_current_branch", return_value="main")
+    fake_run = mocker.patch("pygitgo.utils.executor.run_command", side_effect=["", "", "0"])
+    
+    from pygitgo.commands.git_core import abort_pull_conflict
+    result = abort_pull_conflict()
+    
+    assert result is True
+    fake_run.assert_any_call(["git", "reset", "--hard", "ORIG_HEAD"], loading_msg="Reverting to pre-pull state...", ok_text="Branch reset to its state before the last pull.")

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -1,5 +1,5 @@
 from pygitgo.commands.jump import undo_jump_operation, jump_operation
-from pygitgo.exceptions import GitCommandError
+from pygitgo.exceptions import GitCommandError, GitGoError
 from conftest import capture_system_exit_code
 from argparse import Namespace
 import pytest
@@ -84,31 +84,27 @@ def test_jump_operation_not_valid_repo(mocker):
 
 
 def test_jump_operation_has_changes_exit(mocker):
+    # Tests when git_stash_push fails
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
-    fake_warning = mocker.patch('pygitgo.commands.jump.warning')
-    mocker.patch('builtins.input', side_effect=['n'])
     mocker.patch('pygitgo.commands.jump.run_command', return_value='M file.txt')
-
-    assert capture_system_exit_code(lambda: jump_operation(make_args('main'))) == 0
-    fake_warning.assert_any_call("You cannot switch branches with unsaved edits. Jump canceled.")
-
+    mocker.patch('pygitgo.commands.jump.git_stash_push', return_value=False)
+    mocker.patch('pathlib.Path.exists', return_value=False)
+    
+    with pytest.raises(GitGoError, match="Jump aborted: could not save local changes."):
+        jump_operation(make_args('main'))
 
 def test_jump_operation_has_changes_moves_to_branch(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
-    mocker.patch('builtins.input', return_value='y')
-    fake_info = mocker.patch('pygitgo.commands.jump.info')
-    fake_success = mocker.patch('pygitgo.commands.jump.success')
-    mocker.patch('pygitgo.commands.jump.git_stash_push', return_value=True)
+    fake_stash = mocker.patch('pygitgo.commands.jump.git_stash_push', return_value=True)
     mocker.patch('pygitgo.commands.jump.git_stash_apply', return_value=True)
     fake_drop = mocker.patch('pygitgo.commands.jump.git_stash_drop', return_value=True)
     mocker.patch('pygitgo.commands.jump.run_command', side_effect=lambda *a, **kw: 'M file.txt' if a[0] == ['git', 'status', '--porcelain'] else 'ok')
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
-    fake_info.assert_any_call("Changes saved. Jumping to the new branch...")
-    fake_drop.assert_called_once_with(loading_msg="Cleaning up the temporary stash...", ok_text="On 'feature'. Your changes came with you.")
-    fake_success.assert_not_called()
+    fake_stash.assert_called_once()
+    fake_drop.assert_called_once()
 
 
 def test_jump_operation_no_changes(mocker):
@@ -120,30 +116,24 @@ def test_jump_operation_no_changes(mocker):
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
 
-    fake_success.assert_not_called()
-
-
 
 def test_jump_operation_save_changes_error(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
-    fake_warning = mocker.patch('pygitgo.commands.jump.warning')
-    mocker.patch('builtins.input', return_value='y')
-
     mocker.patch('pygitgo.commands.jump.run_command', return_value='M file.txt')
-    mocker.patch(
-        'pygitgo.commands.jump.git_stash_push',
-        return_value=False
-    )
+    mocker.patch('pygitgo.commands.jump.git_stash_push', return_value=False)
+    mocker.patch('pathlib.Path.exists', return_value=True) # Mock index.lock exists
+    fake_warning = mocker.patch('pygitgo.commands.jump.warning')
 
-    assert capture_system_exit_code(lambda: jump_operation(make_args('main'))) == 1
-    fake_warning.assert_called_with("Stash failed. Your working tree may have untracked files.")
+    with pytest.raises(GitGoError):
+        jump_operation(make_args('main'))
+    fake_warning.assert_any_call("A stale lock file is blocking git.")
 
 
 def test_jump_operation_branch_not_exist_cancel_operation(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=False)
-    mocker.patch('builtins.input', side_effect=['y', 'n'])
+    mocker.patch('pygitgo.commands.jump.confirm', return_value=False)
 
     fake_info = mocker.patch('pygitgo.commands.jump.info')
     mocker.patch('pygitgo.commands.jump.run_command', return_value='M file.txt')
@@ -152,9 +142,8 @@ def test_jump_operation_branch_not_exist_cancel_operation(mocker):
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
 
-    fake_info.assert_any_call("Changes saved. Jumping to the new branch...")
-    fake_info.assert_any_call("Exiting without jumping...")
-    fake_pop.assert_called_once_with(loading_msg="Putting your unsaved changes back...")
+    fake_info.assert_any_call("Jump canceled.")
+    fake_pop.assert_called_once()
 
 
 def test_jump_operation_branch_not_exist_create_branch(mocker):
@@ -162,10 +151,7 @@ def test_jump_operation_branch_not_exist_create_branch(mocker):
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=False)
     fake_new_branch = mocker.patch('pygitgo.commands.jump.git_new_branch', return_value=None)
-    mocker.patch('builtins.input', side_effect=['y', 'y'])
-
-    fake_success = mocker.patch('pygitgo.commands.jump.success')
-    fake_info = mocker.patch('pygitgo.commands.jump.info')
+    mocker.patch('pygitgo.commands.jump.confirm', return_value=True)
 
     mocker.patch(
         'pygitgo.commands.jump.run_command',
@@ -176,12 +162,9 @@ def test_jump_operation_branch_not_exist_create_branch(mocker):
     fake_drop = mocker.patch('pygitgo.commands.jump.git_stash_drop', return_value=True)
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
-
-    fake_info.assert_any_call("Changes saved. Jumping to the new branch...")
-    fake_new_branch.assert_called_once_with('feature', ok_text="Branch 'feature' created.")
-    fake_success.assert_not_called()
+    fake_new_branch.assert_called_once()
     fake_apply.assert_called_once()
-    fake_drop.assert_called_once_with(loading_msg="Cleaning up the temporary stash...", ok_text="On 'feature'. Your changes came with you.")
+    fake_drop.assert_called_once()
 
 
 def test_jump_operation_sync_fail_stay(mocker):
@@ -196,15 +179,13 @@ def test_jump_operation_sync_fail_stay(mocker):
         if cmd == ['git', 'status', '--porcelain']:
             return ''
         if cmd[1] == 'pull':
-            raise GitCommandError(cmd, stderr='failed', returncode=1)
+            raise GitCommandError(cmd, stderr='no internet', returncode=1)
         return 'ok'
 
     mocker.patch('pygitgo.commands.jump.run_command', side_effect=_run)
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
-    fake_info.assert_any_call(
-        "On 'feature', but without the latest updates from 'main'."
-    )
+    fake_info.assert_any_call("On 'feature', but not yet synced with 'main'.")
 
 
 def test_jump_operation_merge_conflict_cancel(mocker):
@@ -212,7 +193,7 @@ def test_jump_operation_merge_conflict_cancel(mocker):
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
     mocker.patch('pygitgo.commands.jump.undo_jump_operation', return_value=None)
-    mocker.patch('builtins.input', side_effect=['y', 'n'])
+    mocker.patch('pygitgo.commands.jump.confirm', return_value=False)
 
     fake_error = mocker.patch('pygitgo.commands.jump.error')
 
@@ -221,42 +202,31 @@ def test_jump_operation_merge_conflict_cancel(mocker):
         side_effect=lambda *a, **kw: 'M file.txt' if a[0] == ['git', 'status', '--porcelain'] else 'ok'
     )
     mocker.patch('pygitgo.commands.jump.git_stash_push', return_value=True)
-    mocker.patch(
-        'pygitgo.commands.jump.git_stash_apply',
-        return_value=False
-    )
+    mocker.patch('pygitgo.commands.jump.git_stash_apply', return_value=False)
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
-    fake_error.assert_any_call("MERGE CONFLICT — your changes clash with the target branch.")
+    fake_error.assert_any_call("CONFLICT: Your local changes clash with the target branch.")
 
 
 def test_jump_operation_merge_conflict_stay(mocker):
     mocker.patch('pygitgo.commands.jump.get_current_branch', return_value='master')
     mocker.patch('pygitgo.commands.jump.get_main_branch', return_value='main')
     mocker.patch('pygitgo.commands.jump.is_branch_exist', return_value=True)
-    mocker.patch('builtins.input', side_effect=['y', 'y'])
+    mocker.patch('pygitgo.commands.jump.confirm', return_value=True)
 
     fake_success = mocker.patch('pygitgo.commands.jump.success')
     fake_warning = mocker.patch('pygitgo.commands.jump.warning')
-    fake_info = mocker.patch('pygitgo.commands.jump.info')
 
     mocker.patch(
         'pygitgo.commands.jump.run_command',
         side_effect=lambda *a, **kw: 'M file.txt' if a[0] == ['git', 'status', '--porcelain'] else 'ok'
     )
     mocker.patch('pygitgo.commands.jump.git_stash_push', return_value=True)
-    mocker.patch(
-        'pygitgo.commands.jump.git_stash_apply',
-        return_value=False
-    )
-    fake_drop = mocker.patch('pygitgo.commands.jump.git_stash_drop', return_value=True)
+    mocker.patch('pygitgo.commands.jump.git_stash_apply', return_value=False)
 
     assert capture_system_exit_code(lambda: jump_operation(make_args('feature'))) == 0
-
-    fake_success.assert_any_call("On 'feature'. Conflict markers are in your files.")
-    fake_warning.assert_any_call("Open your editor and fix the conflict lines.")
-    fake_info.assert_any_call("Your stash backup is still saved. Run 'gitgo state list' to see it.")
-    fake_drop.assert_not_called()
+    fake_success.assert_any_call("On 'feature'. Fix the conflict markers in your files.")
+    fake_warning.assert_any_call("Your stash backup is still saved. Run 'gitgo state list' to see it.")
 
 
 def test_jump_keyboard_interrupt_during_checkout(mocker):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -163,7 +163,7 @@ def test_link_keyboard_interrupt_during_commit(mocker):
         link_core("https://github.com/user/repo.git", "Initial commit")
 
     assert exc_info.value.code == 130
-    mock_warning.assert_called_once_with("Link interrupted (Ctrl+C).")
+    mock_warning.assert_any_call("Link interrupted (Ctrl+C).")
     mock_cleanup.assert_called_once_with(
         "https://github.com/user/repo.git",
         True,

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -4,7 +4,10 @@ from pygitgo.utils.cli_io import warning
 from argparse import Namespace
 import pytest
 
-def test_push_new_branch_flag_no_name():
+
+def test_push_new_branch_flag_no_name(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
+
     args = Namespace(branch=None, message="Init commit", new=True, select=False)
     with pytest.raises(GitGoError) as exc_info:
         push_operation(args)
@@ -12,6 +15,7 @@ def test_push_new_branch_flag_no_name():
 
 
 def test_push_new_branch_success(mocker):
+    mocker.patch("pygitgo.commands.push.get_current_branch", return_value="main")
     fake_new_branch = mocker.patch("pygitgo.commands.push.git_new_branch")
     fake_commit = mocker.patch("pygitgo.commands.push.git_commit", return_value=True)
     fake_push = mocker.patch("pygitgo.commands.push.git_push")

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,8 +1,8 @@
 from pygitgo.commands.push import push_operation
 from pygitgo.exceptions import GitGoError
+from pygitgo.utils.cli_io import warning
 from argparse import Namespace
 import pytest
-
 
 def test_push_new_branch_flag_no_name():
     args = Namespace(branch=None, message="Init commit", new=True, select=False)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,105 @@
+from pygitgo.commands.resolve import resolve_operation
+from pygitgo.exceptions import GitCommandError, GitGoError
+from unittest.mock import patch, MagicMock
+from argparse import Namespace
+import pytest
+
+@patch("pygitgo.commands.resolve.abort_pull_conflict")
+def test_resolve_abort_flag(mock_abort):
+    args = Namespace(abort=True)
+    resolve_operation(args)
+    mock_abort.assert_called_once()
+
+@patch("pygitgo.commands.resolve.Path")
+def test_resolve_no_conflict(mock_path):
+    mock_path_instance = MagicMock()
+    mock_path_instance.exists.return_value = False
+    mock_path.return_value = mock_path_instance
+    
+    args = Namespace(abort=False)
+    with pytest.raises(GitGoError, match="No conflict resolution is currently in progress"):
+        resolve_operation(args)
+
+@patch("pygitgo.commands.resolve.subprocess.run")
+@patch("pygitgo.commands.resolve.run_command")
+@patch("pygitgo.commands.resolve.Path")
+@patch("pygitgo.commands.resolve.banner")
+@patch("pygitgo.commands.resolve.yaspin")
+def test_resolve_success(mock_yaspin, mock_banner, mock_path, mock_run, mock_subrun):
+    mock_path_instance = MagicMock()
+    mock_path_instance.exists.return_value = True
+    mock_path.return_value = mock_path_instance
+    
+    mock_run.side_effect = ["", ""]
+    
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_subrun.return_value = mock_result
+    
+    args = Namespace(abort=False)
+    resolve_operation(args)
+    
+    assert mock_run.call_count == 2
+    mock_run.assert_any_call(["git", "status", "--porcelain"])
+    mock_run.assert_any_call(["git", "add", "."], loading_msg="Staging resolved files...", ok_text="Conflict fixes staged.")
+    
+    mock_subrun.assert_called_once()
+    called_args = mock_subrun.call_args
+    assert called_args[0][0] == ["git", "rebase", "--continue"]
+    assert "GIT_EDITOR" in called_args[1]["env"]
+    assert called_args[1]["env"]["GIT_EDITOR"] == "true"
+    
+    mock_banner.assert_called_once()
+
+@patch("pygitgo.commands.resolve.run_command")
+@patch("pygitgo.commands.resolve.Path")
+def test_resolve_status_error(mock_path, mock_run):
+    mock_path_instance = MagicMock()
+    mock_path_instance.exists.return_value = True
+    mock_path.return_value = mock_path_instance
+    
+    mock_run.side_effect = GitCommandError(["git", "status"])
+    
+    args = Namespace(abort=False)
+    with pytest.raises(GitGoError, match="Not inside a git repository"):
+        resolve_operation(args)
+
+@patch("pygitgo.commands.resolve.subprocess.run")
+@patch("pygitgo.commands.resolve.run_command")
+@patch("pygitgo.commands.resolve.Path")
+@patch("pygitgo.commands.resolve.yaspin")
+def test_resolve_still_conflicted(mock_yaspin, mock_path, mock_run, mock_subrun):
+    mock_path_instance = MagicMock()
+    mock_path_instance.exists.return_value = True
+    mock_path.return_value = mock_path_instance
+    
+    mock_run.return_value = ""
+    
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stderr = "you must edit all merge conflicts"
+    mock_subrun.return_value = mock_result
+    
+    args = Namespace(abort=False)
+    with pytest.raises(GitGoError, match="You still have unresolved conflicts"):
+        resolve_operation(args)
+
+@patch("pygitgo.commands.resolve.subprocess.run")
+@patch("pygitgo.commands.resolve.run_command")
+@patch("pygitgo.commands.resolve.Path")
+@patch("pygitgo.commands.resolve.yaspin")
+def test_resolve_other_error(mock_yaspin, mock_path, mock_run, mock_subrun):
+    mock_path_instance = MagicMock()
+    mock_path_instance.exists.return_value = True
+    mock_path.return_value = mock_path_instance
+    
+    mock_run.return_value = ""
+    
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stderr = "some weird error occurred"
+    mock_subrun.return_value = mock_result
+    
+    args = Namespace(abort=False)
+    with pytest.raises(GitGoError, match="Resolve failed: some weird error occurred"):
+        resolve_operation(args)

--- a/tests/test_ssh_utils.py
+++ b/tests/test_ssh_utils.py
@@ -37,7 +37,7 @@ def test_ensure_github_known_host_not_exists(mocker):
 
 def test_check_connection_success(mocker):
     mocker.patch("pygitgo.auth.ssh_utils.ensure_github_known_host")
-    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Hi user! You've successfully authenticated.")
+    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value=("Hi user! You've successfully authenticated.", False, None))
 
     mock_spinner = mocker.MagicMock()
     mocker.patch("yaspin.yaspin", return_value=mock_spinner)
@@ -50,7 +50,7 @@ def test_check_connection_success(mocker):
 
 def test_check_connection_failure(mocker):
     mocker.patch("pygitgo.auth.ssh_utils.ensure_github_known_host")
-    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Permission denied.")
+    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value=("Permission denied.", False, None))
 
     mock_spinner = mocker.MagicMock()
     mocker.patch("yaspin.yaspin", return_value=mock_spinner)
@@ -62,12 +62,12 @@ def test_check_connection_failure(mocker):
 
 
 def test_get_github_username_success(mocker):
-    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Hi Alice! You've successfully authenticated.")
+    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value=("Hi Alice! You've successfully authenticated.", False, None))
     assert get_github_username() == "Alice"
 
 
 def test_get_github_username_failure(mocker):
-    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value="Permission denied.")
+    mocker.patch("pygitgo.auth.ssh_utils._get_github_ssh_response", return_value=("Permission denied.", False, None))
     assert get_github_username() is None
 
 

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -16,13 +16,20 @@ def test_undo_commit_success(mock_success, mock_run_command):
     )
     mock_success.assert_not_called()
 
+@patch("pygitgo.commands.undo.run_command")
+@patch("pygitgo.commands.undo.success")
+def test_undo_commit_initial_fallback(mock_success, mock_run_command):
+    mock_run_command.side_effect = [GitCommandError(["git", "reset"]), None]
+    undo_commit()
+    assert mock_run_command.call_count == 2
+    mock_run_command.assert_any_call(["git", "update-ref", "-d", "HEAD"], loading_msg="Undoing initial commit...", ok_text="Initial commit undone. Files are back to staged.")
 
 @patch("pygitgo.commands.undo.run_command")
-def test_undo_commit_failure(mock_run_command):
-    mock_run_command.side_effect = GitCommandError(["git", "reset", "--soft", "HEAD~"])
+def test_undo_commit_total_failure(mock_run_command):
+    mock_run_command.side_effect = [GitCommandError(["git", "reset"]), GitCommandError(["git", "update-ref"])]
     with pytest.raises(GitGoError):
         undo_commit()
-    mock_run_command.assert_called_once()
+    assert mock_run_command.call_count == 2
 
 
 @patch("pygitgo.commands.undo.run_command")


### PR DESCRIPTION
## Type
- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [x] Refactor / internal

## Changes
- `gitgo resolve`: added a new command to finish a pull when you get a merge conflict. it stages files and finishes the sync so you don't get stuck in vim.
- `gitgo resolve --abort`: added a flag to cancel a merge conflict and go back to normal.
- `gitgo undo pull`: added a command to undo a pull. it uses `ORIG_HEAD` to go back to how things were before the pull.
- `gitgo jump`: changed how this works. it now auto-saves your changes automatically and pulls better. it also warns you if git is locked.
- `gitgo push`: reads the real git error now. if push fails, it tells you exactly why (like missing remote or wrong password).
- `gitgo link` / `git_remote.py`: catches internet problems and ssh key errors and prints a clear message.
- `gitgo repo`: detects 403 errors and tells you if your github token is missing the right permissions.
- `main.py`: added a global check to stop ugly python crash errors from showing on the screen.
- `init.py`: tells you to manually delete the project folder if windows locks it and blocks the automatic cleanup.
- `executor.py`: tells you if you are missing commands like `git` on windows instead of showing a weird system error.

## Checklist
- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md)
- [x] `README.md` updated (if a command was added or changed)
- [x] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)