### PR TITLE
feat: add gitgo log command and formatted help examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Log:** Added `gitgo log` command to view commit history with a color-coded and structured output.
+- **CLI Docs:** Improved help documentation (`-h`) across all commands (like `resolve`, `push`, `undo`, `jump`, `link`, `user`) by adding examples and consistent formatting.
+
 ### Changed
 - **Safety:** Changed `gitgo undo push` to use `--force-with-lease` to prevent accidentally overwriting remote changes.
 - **UX:** Updated the confirm prompt to accept "yes" as a valid input.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,6 @@ Before picking one, clone the repo and read through the [Project Structure](#pro
 
 | Task | Difficulty | Where to start | What to do |
 |------|------------|----------------|------------|
-| `gitgo log` | ⭐ | `utils/colors.py` | Wrap `git log --oneline --color` and format the output using the existing color helpers. |
 | `gitgo amend` | ⭐ | New command file | Wrap `git commit --amend -m "<message>"`. Add a confirmation prompt before it runs, because amend rewrites history, so the user should opt in. |
 | `gitgo diff` | ⭐ | New command file | Wrap `git diff` and `git diff --staged`. Add a `-s` / `--staged` flag to toggle between unstaged and staged output. |
 | GitLab & Bitbucket SSH | ⭐⭐ | `auth/ssh_utils.py` | The host regex only matches `github.com`. Extend it to cover `gitlab.com` and `bitbucket.org`. |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ gitgo new my-app python
 - **Remote repo creation with `repo`:** Creates a GitHub repo directly from the terminal without touching a browser.
 - **Undo:** Roll back commits, unstage files, discard local changes, or revert pushes. The subcommands say what they do: `undo commit`, `undo add`, `undo changes`, `undo link`, `undo push`, `undo pull`.
 - **Conflict resolution with `resolve`:** Finish a pull after fixing a merge conflict. Verifies the conflict markers are actually gone before staging and completing it. Back out anytime with `resolve --abort`.
+- **Commit history with `log`:** View a beautifully color-coded and structured commit history.
 - **Branch switching with `jump`:** Stashes your uncommitted work, moves to the target branch, syncs with main, and pops the stash. If a merge conflict occurs, the Try-and-Revert engine offers to roll the whole operation back.
 - **State management:** Named, indexed stash. Run `state list` to see what you saved. No more `stash@{2}` archaeology.
 - **Custom defaults:** Store your preferred branch name and default commit message. GitGo picks them up on every run.
@@ -361,6 +362,16 @@ gitgo state delete -a         # delete all saved states
 ```
 
 *Short aliases:* `-l`, `-s`, `-o`, `-d`
+
+### `gitgo log`
+
+Show commit history with a color-coded output.
+
+```bash
+gitgo log                  # show last 5 commits for current branch
+gitgo log -n 10            # show last 10 commits
+gitgo log -b main          # show commits for the main branch
+```
 
 ### `gitgo user`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.9.1"
+version = "1.10.0"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/auth/account.py
+++ b/src/pygitgo/auth/account.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import info, success, warning, error
+from pygitgo.utils.cli_io import info, success, warning, error, write
 from pygitgo.utils.executor import run_command
 from pygitgo.exceptions import GitCommandError
 from pygitgo.utils.colors import BLUE, RESET
@@ -26,8 +26,8 @@ def set_user(name, email):
     run_command(["git", "config", "--global", "user.name", name])
     run_command(["git", "config", "--global", "user.email", email])
     success("\nGit user configured successfully.")
-    print(f"{BLUE}Username{RESET} : {name}")
-    print(f"{BLUE}Email    {RESET}: {email}")
+    write(f"{BLUE}Username{RESET} : {name}")
+    write(f"{BLUE}Email    {RESET}: {email}")
 
 def ensure_user_configure(default_email=None, default_username=None):
 
@@ -41,12 +41,12 @@ def ensure_user_configure(default_email=None, default_username=None):
         set_user(default_username, default_email)
         return True
     
-    print()
-    print("  Git Identity Setup")
-    print("  " + "-" * 36)
+    write()
+    write("  Git Identity Setup")
+    write("  " + "-" * 36)
     warning("Git user identity is not configured.")
     info("Needed so your commits are attributed to the right account.")
-    print()
+    write()
 
     if default_username:
         new_username = default_username

--- a/src/pygitgo/auth/manager.py
+++ b/src/pygitgo/auth/manager.py
@@ -1,10 +1,11 @@
-from pygitgo.utils.cli_io import info, success, warning, error
+from pygitgo.utils.cli_io import info, success, warning, error, write
 from pygitgo.utils.platform import get_platform
 from pygitgo.utils.executor import run_command
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.platform import open_url
 from . import ssh_utils
 import os
+
 
 
 def _configure_ssh_signing(key_path):
@@ -61,11 +62,11 @@ def login():
 
     success("SSH Key generated successfully!")
 
-    print()
-    print("  Your SSH public key:")
-    print()
-    print(f"  {pub_key.strip()}")
-    print()
+    write()
+    write("  Your SSH public key:")
+    write()
+    write(f"  {pub_key.strip()}")
+    write()
 
     info("Copy the key above, then add it TWICE on GitHub:")
     info("  1. Authentication Key  (for pushing and pulling)")

--- a/src/pygitgo/commands/git_remote.py
+++ b/src/pygitgo/commands/git_remote.py
@@ -1,5 +1,5 @@
 from pygitgo.exceptions import GitCommandError, GitGoError
-from pygitgo.utils.cli_io import info, warning, error
+from pygitgo.utils.cli_io import info, warning, error, write
 from pygitgo.utils.executor import run_command
 
 
@@ -49,7 +49,7 @@ def check_and_sync_branch(branch):
                     warning(f"Local branch is behind remote by {behind_check} commit(s). Pulling changes...")
                     output = run_command(["git", "pull", "--rebase", "origin", branch], loading_msg="Pulling changes from remote...", ok_text="Synced with remote.")
                     if output:
-                        print(output)
+                        write(output)
                 else:
                     info("Branch is up to date.")
             else:

--- a/src/pygitgo/commands/jump.py
+++ b/src/pygitgo/commands/jump.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import warning, info, success, error, confirm, banner
+from pygitgo.utils.cli_io import warning, info, success, error, confirm, banner, write
 from pygitgo.commands.git_branch import (
     is_branch_exist, get_current_branch, git_new_branch, get_main_branch,
 )
@@ -95,7 +95,7 @@ def jump_operation(args):
             stashed_code = True
 
         if not is_branch_exist(target_branch):
-            print()
+            write()
             warning(f"Branch '{target_branch}' does not exist.")
             if not confirm(f"Create '{target_branch}' and switch to it? (y/n): "):
                 info("Jump canceled.")
@@ -134,17 +134,17 @@ def jump_operation(args):
         if stashed_code:
             apply_result = git_stash_apply(loading_msg="Restoring your local changes...")
             if not apply_result:
-                print()
+                write()
                 error("CONFLICT: Your local changes clash with the target branch.")
-                print()
+                write()
                 info("Option [Y]: Stay here and fix the conflict lines in your files.")
                 info("Option [N]: Undo the switch and go back to where you started.")
-                print()
+                write()
                 if not confirm("Fix the conflicts yourself? (y = stay / n = go back): "):
                     undo_jump_operation(original_branch, stashed_code, created_branch)
                     return
                 else:
-                    print()
+                    write()
                     success(f"On '{target_branch}'. Fix the conflict markers in your files.")
                     warning("Your stash backup is still saved. Run 'gitgo state list' to see it.")
                     return
@@ -158,7 +158,7 @@ def jump_operation(args):
         return
 
     except KeyboardInterrupt:
-        print()
+        write()
         warning("Jump interrupted (Ctrl+C).")
         _jump_interrupt_cleanup(original_branch, stashed_code, created_branch)
         sys.exit(130)

--- a/src/pygitgo/commands/link.py
+++ b/src/pygitgo/commands/link.py
@@ -1,5 +1,5 @@
 from pygitgo.commands.git_remote import add_remote_origin, confirm_remote_link
-from pygitgo.utils.cli_io import success, warning, error, info, banner
+from pygitgo.utils.cli_io import success, warning, error, info, banner, write
 from pygitgo.commands.git_core import git_init, git_commit, git_push
 from pygitgo.commands.git_branch import get_current_branch
 from pygitgo.auth.ssh_utils import ensure_github_known_host, convert_https_to_ssh, is_ssh_url, check_connection
@@ -126,11 +126,11 @@ def link_core(repo_url, commit_message, silent=False, already_initialized=False)
 
         if not silent:
             banner("REPOSITORY INITIALIZED AND DEPLOYED.", "LOCAL REPOSITORY CONNECTED TO REMOTE ORIGIN.")
-            print()
+            write()
             info("Run 'gitgo undo link' to remove the remote and undo the initial commit.")
 
     except KeyboardInterrupt:
-        print()
+        write()
         warning("Link interrupted (Ctrl+C).")
         _link_interrupt_cleanup(repo_url, initialized, committed, remote_added)
         sys.exit(130)

--- a/src/pygitgo/commands/log.py
+++ b/src/pygitgo/commands/log.py
@@ -1,0 +1,61 @@
+from pygitgo.commands.git_branch import is_branch_exist, get_current_branch
+from pygitgo.utils.colors import YELLOW, CYAN, GREEN, RESET
+from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.utils.cli_io import info, write, banner
+from pygitgo.utils.executor import run_command
+
+def log_operation(args):
+    number = args.number
+    branch = args.branch
+    
+    try:
+        run_command(["git", "rev-parse", "--is-inside-work-tree"])
+    except GitCommandError:
+        raise GitGoError("Not inside a git repository. Run 'gitgo init' or 'gitgo link' first.")
+    
+    try:
+        run_command(["git", "rev-parse", "HEAD"])
+    except GitCommandError:
+        info("No commits found in this repository.")
+        return
+
+    if branch:
+        if not is_branch_exist(branch):
+            raise GitGoError(f"Branch '{branch}' does not exist.")
+        target_branch = branch
+    else:
+        try:
+            target_branch = get_current_branch()
+        except Exception:
+            target_branch = ""
+
+    command = [
+        "git", "log", 
+        f"-n{number}",
+        "--pretty=format:%h||%an||%cr||%s"
+    ]
+    
+    if branch:
+        command.append(branch)
+        
+    try:
+        output = run_command(command)
+        if not output:
+            info("No commits found.")
+            return
+            
+        banner_subtitle = f"Showing last {number} commits"
+        if target_branch:
+            banner_subtitle += f" on {target_branch}"
+            
+        banner("Commit History", banner_subtitle)
+        
+        for line in output.splitlines():
+            try:
+                commit_hash, author, date, message = line.split("||", 3)
+                write(f"[{YELLOW}{commit_hash}{RESET}] {message} ({CYAN}{date}{RESET}) [{GREEN}{author}{RESET}]")
+            except ValueError:
+                write(line)
+        write()
+    except GitCommandError as e:
+        raise GitGoError(f"Failed to retrieve log: {getattr(e, 'stderr', str(e))}")

--- a/src/pygitgo/commands/new.py
+++ b/src/pygitgo/commands/new.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import info, error, warning, confirm, success, banner
+from pygitgo.utils.cli_io import info, error, warning, confirm, success, banner, write
 from pygitgo.commands.init import init_operation
 from pygitgo.commands.repo import repo_operation
 from pygitgo.utils.platform import get_platform
@@ -61,6 +61,6 @@ def new_operation(args):
 
     banner("PROJECT LAUNCHED. SCAFFOLDED, CREATED, AND DEPLOYED.", "LOCAL STRUCTURE ESTABLISHED AND REMOTE SYNCED.")
 
-    print()
+    write()
     info("Run 'gitgo undo link' to remove the remote and undo the initial commit.")
 

--- a/src/pygitgo/commands/pull.py
+++ b/src/pygitgo/commands/pull.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import success, warning, error, info
+from pygitgo.utils.cli_io import success, warning, error, info, write
 from pygitgo.commands.git_branch import get_current_branch
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
@@ -61,7 +61,7 @@ def pull_operation(args):
         banner("REMOTE SYNCHRONIZED. LATEST CHANGES ACQUIRED.", "LOCAL WORKSPACE UPDATED AND ALIGNED.")
 
     except KeyboardInterrupt:
-        print()
+        write()
         warning("Pull interrupted (Ctrl+C).")
         _pull_interrupt_cleanup()
         sys.exit(130)
@@ -70,15 +70,15 @@ def pull_operation(args):
         error_msg = str(e).lower()
         if "conflict" in error_msg or "rebase in progress" in error_msg:
             error("MERGE CONFLICT DETECTED!")
-            print()
+            write()
             info("1. Open your code editor.")
             info("2. Fix the conflict lines in your files.")
             info("3. Save the files.")
             info("4. Run:  gitgo resolve")
-            print()
+            write()
             info("Or, to cancel the pull and go back to how things were:")
             info("Run:  gitgo resolve --abort")
-            print()
+            write()
             raise GitGoError("Pull failed — resolve conflicts to continue.")
         else:
             raise GitGoError(f"Failed to pull from remote: {e}")

--- a/src/pygitgo/commands/push.py
+++ b/src/pygitgo/commands/push.py
@@ -1,6 +1,6 @@
 from pygitgo.commands.staging import get_changed_files, display_file_picker, selective_stage
 from pygitgo.commands.git_branch import git_new_branch, get_current_branch, is_branch_exist
-from pygitgo.utils.cli_io import info, warning, success, confirm, banner
+from pygitgo.utils.cli_io import info, warning, success, confirm, banner, write
 from pygitgo.commands.git_core import git_commit, git_push
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.commands.jump import jump_operation
@@ -148,7 +148,7 @@ def push_operation(args):
 
         banner("MISSION COMPLETE. ALL TARGETS COMMITTED AND PUSHED.", "REMOTE TARGETS ALIGNED WITH LOCAL EDITS.")
 
-        print()
+        write()
         if auto_switched_from:
             info(f"Switched from '{auto_switched_from}' to '{branch}' automatically.")
             info(f"Run 'gitgo undo push' to revert the push, then 'gitgo jump {auto_switched_from}' to return.")
@@ -156,7 +156,7 @@ def push_operation(args):
             info("Run 'gitgo undo push' to revert this push if it was unintended.")
 
     except KeyboardInterrupt:
-        print()
+        write()
         warning("Push interrupted (Ctrl+C).")
         _push_interrupt_cleanup(original_branch, original_head, created_branch)
         sys.exit(130)

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import info, success, warning, error, confirm, banner
+from pygitgo.utils.cli_io import info, success, warning, error, confirm, banner, write
 from pygitgo.commands.stash import (
     git_stash_apply, git_stash_clear, git_stash_drop,
     git_stash_list, git_stash_push
@@ -47,16 +47,16 @@ def display_save_states(save_state=None):
         info("No saved states found.")
         return
 
-    print("\nID | Date                | Saved State")
-    print("-" * 60)
+    write("\nID | Date                | Saved State")
+    write("-" * 60)
 
     for state in save_states:
-        print(
+        write(
             f"{state['id']:>2} | {state['date']} | {state['message']}"
         )
 
-    print("-" * 60)
-    print()
+    write("-" * 60)
+    write()
 
 
 def is_number(value):
@@ -84,7 +84,7 @@ def ask_state_id(save_states):
     state_id = None
 
     display_save_states(save_states)
-    print("Enter the ID (or 'q' to cancel):")
+    write("Enter the ID (or 'q' to cancel):")
 
     while not proceed:
         state_id = input(">> ").strip().lower()
@@ -136,7 +136,7 @@ def load_state(state_id=None):
         banner("WORKSPACE SNAPSHOT RESTORED.", "SECURE VAULT WORKSPACE RE-APPLIED TO TREE.")
 
     except KeyboardInterrupt:
-        print()
+        write()
         warning("State load interrupted (Ctrl+C).")
         try:
             run_command(["git", "checkout", "--", "."])

--- a/src/pygitgo/commands/undo.py
+++ b/src/pygitgo/commands/undo.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import success, warning, info, confirm, danger, banner
+from pygitgo.utils.cli_io import success, warning, info, confirm, danger, banner, write
 from pygitgo.commands.git_branch import get_current_branch
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
@@ -36,7 +36,7 @@ def undo_changes():
         return True
 
     except KeyboardInterrupt:
-        print()
+        write()
         if reset_done:
             warning("Interrupted during file removal. Finishing cleanup...")
             try:

--- a/src/pygitgo/commands/user.py
+++ b/src/pygitgo/commands/user.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import info, warning, banner
+from pygitgo.utils.cli_io import info, warning, banner, write
 from pygitgo.auth.manager import login, logout
 from pygitgo.auth.account import get_user
 from pygitgo.exceptions import GitGoError
@@ -9,12 +9,12 @@ def display_current_user():
     username, email = get_user()
     if username and email:
         width = min(shutil.get_terminal_size().columns, 40)
-        print()
-        print("=" * width)
+        write()
+        write("=" * width)
         info(f"Git User:  {username}")
         info(f"Git Email: {email}")
-        print("=" * width)
-        print()
+        write("=" * width)
+        write()
     else:
         warning("No Git user identity configured.")
         info("Run 'gitgo user login'")

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -1,6 +1,6 @@
 from pygitgo.utils.update_checker import check_for_updates_background, check_for_updates
 from pygitgo.utils.bootstrap import ensure_first_run_setup
-from pygitgo.utils.cli_io import info, warning, error
+from pygitgo.utils.cli_io import info, warning, error, write
 from pygitgo.commands.config import config_operation
 from pygitgo.commands.state import state_operation
 from pygitgo.commands.undo import undo_operation
@@ -11,7 +11,9 @@ from pygitgo.commands.push import push_operation
 from pygitgo.commands.user import user_operation
 from pygitgo.commands.repo import repo_operation
 from pygitgo.commands.init import init_operation
+from pygitgo.commands.log import log_operation
 from pygitgo.commands.new import new_operation
+from pygitgo.utils.cli_io import set_verbosity
 from pygitgo.commands.resolve import resolve_operation
 from pygitgo.exceptions import GitGoError
 import argparse
@@ -37,13 +39,33 @@ def main():
     parser.add_argument("-v", "-V", "--version", action="store_true", help="show program's version number and exit")
     parser.add_argument("-r", "--ready", action="store_true", help="Check tool readiness")
 
+    parser.add_argument("-q", "--quiet", action="store_true", help="Hide all non-error output")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose debug output")
+
     subparsers = parser.add_subparsers(title="Commands", dest="command")
     subparsers.required = False
 
-    jump_parser = subparsers.add_parser("jump", help="Safely switch branches with try-and-revert")
+    jump_parser = subparsers.add_parser(
+        "jump", 
+        help="Safely switch branches with try-and-revert",
+        epilog=(
+            "Examples:\n"
+            "  gitgo jump feature/login          Switch to 'feature/login' branch"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     jump_parser.add_argument("branch", help="The name of the branch to jump to")
 
-    link_parser = subparsers.add_parser("link", help="Init, commit, and link to a remote repo")
+    link_parser = subparsers.add_parser(
+        "link", 
+        help="Init, commit, and link to a remote repo",
+        epilog=(
+            "Examples:\n"
+            "  gitgo link https://github.com/user/repo.git               Link to a remote repo\n"
+            "  gitgo link https://github.com/user/repo.git 'First commit' Link with custom commit message"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     link_parser.add_argument("url", help="The GitHub repository URL to link")
     link_parser.add_argument("message", nargs="?", default="Initial commit", help="Custom commit message")
 
@@ -104,7 +126,16 @@ def main():
         help="Apply action to all states (e.g., delete all)"
     )
     
-    user_parser = subparsers.add_parser("user", help="Manage Git user identity")
+    user_parser = subparsers.add_parser(
+        "user", 
+        help="Manage Git user identity",
+        epilog=(
+            "Examples:\n"
+            "  gitgo user login                  Authenticate with Git provider\n"
+            "  gitgo user logout                 Remove authentication credentials"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     user_parser.add_argument("action", nargs="?", choices=["login", "logout"], default=None, help="login or logout")
 
     config_parser = subparsers.add_parser("config",
@@ -153,7 +184,13 @@ def main():
 
     resolve_parser = subparsers.add_parser("resolve", 
         help="Resolve a paused sync after fixing a merge conflict",
-        description="Automatically stages your resolved files and finishes the active merge conflict, bypassing the text editor."
+        description="Automatically stages your resolved files and finishes the active merge conflict, bypassing the text editor.",
+        epilog=(
+            "Examples:\n"
+            "  gitgo resolve                     Finish merge conflict after fixing files\n"
+            "  gitgo resolve --abort             Cancel the merge/rebase and revert to pre-pull state"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter
     )
     resolve_parser.add_argument("--abort", action="store_true", help="Abort the current merge/rebase and revert to the pre-pull state")
 
@@ -259,7 +296,36 @@ def main():
         help="Short repository description shown on GitHub."
     )
 
+    log_parser = subparsers.add_parser(
+        "log",
+        help="Show commit history",
+        epilog=(
+            "Examples:\n"
+            "  gitgo log                         Show last 5 commits for current branch\n"
+            "  gitgo log -n 10                   Show last 10 commits\n"
+            "  gitgo log -b main                 Show commits for the 'main' branch\n"
+            "  gitgo log -b feature -n 3         Show last 3 commits for 'feature' branch"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    log_parser.add_argument(
+        "-n", "--number",
+        dest="number",
+        type=int,
+        default=5,
+        metavar="NUMBER",
+        help="Number of commits to show."
+    )
+    log_parser.add_argument(
+        "-b", "--branch",
+        default=None,
+        metavar="BRANCH",
+        help="Branch to show commits for."
+    )
+
     args = parser.parse_args()
+
+    set_verbosity(quiet=args.quiet, verbose=getattr(args, 'verbose', False))
 
     if getattr(args, 'version', False):
         current_v = get_version()
@@ -280,36 +346,31 @@ def main():
     ensure_first_run_setup()
     check_for_updates_background(get_version())
 
+    COMMANDS = {
+        "push": push_operation,
+        "link": link_operation,
+        "jump": jump_operation,
+        "state": state_operation,
+        "user": user_operation,
+        "resolve": resolve_operation,
+        "config": config_operation,
+        "undo": undo_operation,
+        "pull": pull_operation,
+        "repo": repo_operation,
+        "new": new_operation,
+        "init": lambda a: init_operation(a, standalone=True),
+        "log": log_operation,
+    }
+
     try:
-        if args.command == "jump":
-            jump_operation(args)
-        elif args.command == "link":
-            link_operation(args)
-        elif args.command == "push":
-            push_operation(args)
-        elif args.command == "state":
-            state_operation(args)
-        elif args.command == "user":
-            user_operation(args)
-        elif args.command == "resolve":
-            resolve_operation(args)
-        elif args.command == "config":
-            config_operation(args)
-        elif args.command == "undo":
-            undo_operation(args)
-        elif args.command == "pull":
-            pull_operation(args)
-        elif args.command == "repo":
-            repo_operation(args)
-        elif args.command == "new":
-            new_operation(args)
-        elif args.command == "init":
-            init_operation(args, standalone=True)
+        handler = COMMANDS.get(args.command)
+        if handler:
+            handler(args)
     except GitGoError as e:
         error(f"{e}")
         sys.exit(1)
     except KeyboardInterrupt:
-        print()
+        write()
         warning("Operation canceled.")
         sys.exit(130)
     except Exception as e:

--- a/src/pygitgo/utils/cli_io.py
+++ b/src/pygitgo/utils/cli_io.py
@@ -1,6 +1,8 @@
 from pygitgo.utils.colors import RED, GREEN, YELLOW, BLUE, CYAN, RESET
 import shutil
 
+_QUIET = False
+_VERBOSE = False
 
 def confirm(prompt, destructive=False):
     prefix = ""
@@ -12,19 +14,27 @@ def confirm(prompt, destructive=False):
 def danger(msg):
     print(f"{RED}DANGER: {msg.strip()}{RESET}")
 
-def warning(msg):
-    print(f"{YELLOW}WARNING: {msg.strip()}{RESET}")
-
 def error(msg):
     print(f"{RED}{msg.strip()}{RESET}")
 
+def warning(msg):
+    if _QUIET:
+        return
+    print(f"{YELLOW}WARNING: {msg.strip()}{RESET}")
+
 def info(msg):
+    if _QUIET:
+        return
     print(f"{BLUE}{msg.strip()}{RESET}")
 
 def success(msg):
+    if _QUIET:
+        return
     print(f"{GREEN}{msg.strip()}{RESET}")
 
 def banner(title, subtitle=""):
+    if _QUIET:
+        return
     width = min(shutil.get_terminal_size().columns, 72)
     print()
     print(GREEN + ("=" * width) + RESET)
@@ -33,3 +43,18 @@ def banner(title, subtitle=""):
         print(CYAN + subtitle.center(width) + RESET)
     print(GREEN + ("=" * width) + RESET)
     print()
+
+def write(msg="", end="\n"):
+    if _QUIET:
+        return
+    print(msg, end=end)
+
+def set_verbosity(quiet=False, verbose=False):
+    global _QUIET, _VERBOSE
+    _QUIET = quiet 
+    _VERBOSE = verbose
+
+
+
+
+

--- a/src/pygitgo/utils/executor.py
+++ b/src/pygitgo/utils/executor.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import error, info, success, warning, confirm, danger
+from pygitgo.utils.cli_io import error, info, success, warning, confirm, danger, _QUIET, _VERBOSE
 from pygitgo.exceptions import GitCommandError
 from yaspin import yaspin
 import subprocess
@@ -12,7 +12,7 @@ def run_command(command, return_complete=False, loading_msg=None, ok_text=None, 
     kwargs = {"text": loading_msg}
     if sys.stdout.isatty():
         kwargs["color"] = "cyan"
-    spinner = yaspin(**kwargs) if loading_msg else None
+    spinner = yaspin(**kwargs) if (loading_msg and not _QUIET) else None
 
     if spinner:
         spinner.start()
@@ -26,6 +26,10 @@ def run_command(command, return_complete=False, loading_msg=None, ok_text=None, 
         if extra_env:
             env.update(extra_env)
 
+        if _VERBOSE:
+            cmd_str = " ".join(command) if isinstance(command, list) else command
+            print(f"[DEBUG] Running command: {cmd_str}")
+
         result = subprocess.run(
             command,
             check=True,
@@ -34,6 +38,12 @@ def run_command(command, return_complete=False, loading_msg=None, ok_text=None, 
             stdin=subprocess.DEVNULL,
             env=env,
         )
+
+        if _VERBOSE:
+            if result.stdout.strip():
+                print(f"[DEBUG] stdout:\n{result.stdout.strip()}")
+            if result.stderr.strip():
+                print(f"[DEBUG] stderr:\n{result.stderr.strip()}")
 
         if spinner:
             if ok_text:
@@ -62,6 +72,12 @@ def run_command(command, return_complete=False, loading_msg=None, ok_text=None, 
                 )
             else:
                 stderr = f"Failed to run '{cmd_name}': {e}"
+
+        if _VERBOSE:
+            print(f"[DEBUG] Command failed with exit code: {returncode}")
+            if stderr:
+                print(f"[DEBUG] stderr:\n{stderr}")
+
 
         if "detected dubious ownership" in stderr:
             danger("Git blocked this folder for security reasons (dubious ownership).")

--- a/src/pygitgo/utils/platform.py
+++ b/src/pygitgo/utils/platform.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import warning, info
+from pygitgo.utils.cli_io import warning, info, write
 import webbrowser
 import subprocess
 import platform
@@ -46,5 +46,5 @@ def open_url(url: str):
     if not opened:
         warning("Could not open browser automatically.")
         info("\nIf the browser did not open, visit this URL manually:")
-        print(f"\n  {url}\n")
+        write(f"\n  {url}\n")
 

--- a/src/pygitgo/utils/update_checker.py
+++ b/src/pygitgo/utils/update_checker.py
@@ -1,4 +1,4 @@
-from pygitgo.utils.cli_io import info, warning
+from pygitgo.utils.cli_io import info, warning, write
 from datetime import datetime, timedelta
 from pathlib import Path
 import urllib.request
@@ -81,10 +81,10 @@ def check_for_updates(current_version):
         latest_parts = parse_version(latest_version)
 
         if latest_parts > current_parts:
-            print()
+            write()
             warning(f"GitGo update available: {current_version} -> {latest_version}")
             info("Run: pip install --upgrade pygitgo")
-            print()
+            write()
 
             cache["notified_version"] = latest_version
             write_cache(cache)

--- a/tests/test_cli_io.py
+++ b/tests/test_cli_io.py
@@ -49,3 +49,31 @@ def test_banner(mocker):
     
     # Check that print was called to output the banner
     assert mock_print.call_count >= 4
+
+def test_quiet_mode(mocker):
+    from pygitgo.utils.cli_io import set_verbosity, write
+    mock_print = mocker.patch("builtins.print")
+    
+    # Enable quiet mode
+    set_verbosity(quiet=True)
+    try:
+        info("quiet info")
+        success("quiet success")
+        warning("quiet warning")
+        banner("quiet banner")
+        write("quiet write")
+        
+        # None of these should call print
+        assert mock_print.call_count == 0
+        
+        # But error and danger should still print
+        error("quiet error")
+        assert mock_print.call_count == 1
+        
+        danger("quiet danger")
+        assert mock_print.call_count == 2
+    finally:
+        # Reset verbosity
+        set_verbosity(quiet=False)
+
+

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -90,3 +90,22 @@ def test_run_command_dubious_ownership_decline(mocker):
     
     mock_confirm.assert_called_once()
     mock_warning.assert_called_with("Fix declined. Operations in this directory will continue to fail.")
+
+def test_run_command_verbose(mocker):
+    mocker.patch("pygitgo.utils.executor._VERBOSE", True)
+    mock_print = mocker.patch("builtins.print")
+    
+    mock_run = mocker.patch("subprocess.run")
+    mock_result = mocker.MagicMock()
+    mock_result.stdout = "hello stdout"
+    mock_result.stderr = "hello stderr"
+    mock_run.return_value = mock_result
+    
+    res = run_command(["echo", "hello"])
+    assert res == "hello stdout"
+    
+    # Check that print was called with debugging info
+    mock_print.assert_any_call("[DEBUG] Running command: echo hello")
+    mock_print.assert_any_call("[DEBUG] stdout:\nhello stdout")
+    mock_print.assert_any_call("[DEBUG] stderr:\nhello stderr")
+

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,73 @@
+import pytest
+from pygitgo.commands.log import log_operation
+from pygitgo.exceptions import GitCommandError, GitGoError
+from argparse import Namespace
+
+@pytest.fixture
+def base_args():
+    return Namespace(number=5, branch=None)
+
+def test_log_operation_success(mocker, base_args):
+    mock_run = mocker.patch("pygitgo.commands.log.run_command")
+    
+    # Mock rev-parse (is-inside-work-tree)
+    # Mock rev-parse HEAD (commits exist)
+    # Mock log command output
+    mock_run.side_effect = [
+        "true",  # rev-parse --is-inside-work-tree
+        "abc1234",  # rev-parse HEAD
+        "abc1234||User Name||2 hours ago||Initial commit"  # git log
+    ]
+    
+    mock_branch = mocker.patch("pygitgo.commands.log.get_current_branch", return_value="main")
+    mock_write = mocker.patch("pygitgo.commands.log.write")
+    mock_banner = mocker.patch("pygitgo.commands.log.banner")
+    
+    log_operation(base_args)
+    
+    mock_banner.assert_called_once_with("Commit History", "Showing last 5 commits on main")
+    mock_write.assert_any_call("[\033[33mabc1234\033[0m] Initial commit (\033[36m2 hours ago\033[0m) [\033[32mUser Name\033[0m]")
+
+def test_log_not_git_repo(mocker, base_args):
+    mock_run = mocker.patch("pygitgo.commands.log.run_command")
+    mock_run.side_effect = GitCommandError(["git"], "fatal: not a git repository")
+    
+    with pytest.raises(GitGoError, match="Not inside a git repository"):
+        log_operation(base_args)
+
+def test_log_no_commits(mocker, base_args):
+    mock_run = mocker.patch("pygitgo.commands.log.run_command")
+    mock_run.side_effect = [
+        "true",
+        GitCommandError(["git"], "fatal: ambiguous argument 'HEAD': unknown revision")
+    ]
+    
+    mock_info = mocker.patch("pygitgo.commands.log.info")
+    
+    log_operation(base_args)
+    mock_info.assert_called_once_with("No commits found in this repository.")
+
+def test_log_invalid_branch(mocker, base_args):
+    base_args.branch = "nonexistent"
+    
+    mock_run = mocker.patch("pygitgo.commands.log.run_command", return_value="true")
+    mocker.patch("pygitgo.commands.log.is_branch_exist", return_value=False)
+    
+    with pytest.raises(GitGoError, match="Branch 'nonexistent' does not exist"):
+        log_operation(base_args)
+
+def test_log_with_branch_success(mocker, base_args):
+    base_args.branch = "feature"
+    
+    mock_run = mocker.patch("pygitgo.commands.log.run_command")
+    mock_run.side_effect = [
+        "true",  # rev-parse --is-inside-work-tree
+        "abc1234",  # rev-parse HEAD
+        "def5678||Bob||1 day ago||Feature added"  # git log
+    ]
+    
+    mocker.patch("pygitgo.commands.log.is_branch_exist", return_value=True)
+    mock_banner = mocker.patch("pygitgo.commands.log.banner")
+    
+    log_operation(base_args)
+    mock_banner.assert_called_once_with("Commit History", "Showing last 5 commits on feature")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,6 +55,7 @@ def test_main_no_command_prints_help(mocker, capsys, _patch_startup):
     ("repo", "repo_operation"),
     ("new", "new_operation"),
     ("init", "init_operation"),
+    ("log", "log_operation"),
 ])
 def test_main_dispatches_command(mocker, _patch_startup, command, handler):
     mocker.patch.object(sys, "argv", ["gitgo", command] + _argv_tail(command))
@@ -78,6 +79,7 @@ def _argv_tail(command):
         "repo": [],
         "new": ["my-app"],
         "init": ["my-app"],
+        "log": [],
     }
     return tails[command]
 


### PR DESCRIPTION
<!-- If you are unsure how to fill this out, see CONTRIBUTING.md: https://github.com/Huerte/GitGo/blob/main/CONTRIBUTING.md -->
<!-- Note: These hidden comments guide you while typing. GitHub hides them automatically when you submit. -->

## Type

<!-- Put an 'x' inside the brackets: [x] -->

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / internal

## Changes
- `gitgo log`: added a new command to view a color-coded and structured commit history.
- `main.py`: added formatted help menus with examples (RawDescriptionHelpFormatter) for `log`, `jump`, `link`, `user`, and `resolve`.
- `CONTRIBUTING.md`: removed the `gitgo log` task from the Good First Issues table.

## Checklist

<!-- Put an 'x' inside the brackets: [x] -->

- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md)
- [x] `README.md` updated (if a command was added or changed)
- [x] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)