### PR TITLE
Fix banner unicode crashes and add git repository checks to commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed target directory lock issues on Windows inside `gitgo init` on scaffolding failures by returning to the original directory before cleanup.
 - Safely handle non-git repository executions in `gitgo` banner by displaying human-readable status instead of throwing exception tracebacks.
+- Added git repository validation across commands (`push`, `pull`, `state`, `undo`, `resolve`) to output friendly error messages when executed outside a git repository.
 
 ### Changed
 - Expanded and cleaned test suite coverage (now at 93% total coverage) across commands and utility modules with clean, uncommented test cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Added robust Unicode print fallback for `show_banner` to prevent crashes on legacy Windows terminals.
+
 ### Fixed
 - Fixed target directory lock issues on Windows inside `gitgo init` on scaffolding failures by returning to the original directory before cleanup.
+- Safely handle non-git repository executions in `gitgo` banner by displaying human-readable status instead of throwing exception tracebacks.
 
 ### Changed
 - Expanded and cleaned test suite coverage (now at 93% total coverage) across commands and utility modules with clean, uncommented test cases.
+- Unified banner box borders to be consistently green across all CLI outputs.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitgo"
-version = "1.10.1"
+version = "1.10.2"
 description = "GitGo CLI - Your Fast Git Companion. Simplifies git push, link, stash, and user management."
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pygitgo/commands/pull.py
+++ b/src/pygitgo/commands/pull.py
@@ -1,5 +1,5 @@
 from pygitgo.utils.cli_io import success, warning, error, info, write
-from pygitgo.commands.git_core import is_rebase_in_progress
+from pygitgo.commands.git_core import is_rebase_in_progress, ensure_inside_git_repository
 from pygitgo.commands.git_branch import get_current_branch
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
@@ -27,6 +27,7 @@ def _pull_interrupt_cleanup():
 
 
 def pull_operation(args):
+    ensure_inside_git_repository()
     branch = args.branch
 
     if not branch:

--- a/src/pygitgo/commands/push.py
+++ b/src/pygitgo/commands/push.py
@@ -1,7 +1,7 @@
 from pygitgo.commands.git_branch import git_new_branch, get_current_branch, is_branch_exist, get_head_sha
 from pygitgo.commands.staging import get_changed_files, display_file_picker, selective_stage
 from pygitgo.utils.cli_io import info, warning, success, confirm, banner, write
-from pygitgo.commands.git_core import git_commit, git_push
+from pygitgo.commands.git_core import git_commit, git_push, ensure_inside_git_repository
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.commands.jump import jump_operation
 from pygitgo.utils.executor import run_command
@@ -59,6 +59,7 @@ def _push_interrupt_cleanup(original_branch, original_head, created_branch):
 
 
 def push_operation(args):
+    ensure_inside_git_repository()
     branch = args.branch
     message = args.message
     select = args.select if hasattr(args, 'select') else False

--- a/src/pygitgo/commands/resolve.py
+++ b/src/pygitgo/commands/resolve.py
@@ -1,10 +1,12 @@
 from pygitgo.utils.cli_io import info, warning, error, banner
 from pygitgo.exceptions import GitCommandError, GitGoError
 from pygitgo.utils.executor import run_command
-from pygitgo.commands.git_core import abort_pull_conflict
+from pygitgo.commands.git_core import abort_pull_conflict, ensure_inside_git_repository
 from pathlib import Path
 
 def resolve_operation(args):
+    ensure_inside_git_repository()
+
     if getattr(args, 'abort', False):
         abort_pull_conflict()
         return
@@ -12,11 +14,6 @@ def resolve_operation(args):
     rebase_in_progress = Path(".git/rebase-merge").exists() or Path(".git/rebase-apply").exists()
     if not rebase_in_progress:
         raise GitGoError("No conflict resolution is currently in progress. You are good to go!")
-        
-    try:
-        run_command(["git", "status", "--porcelain"])
-    except GitCommandError:
-        raise GitGoError("Not inside a git repository.")
         
     # Stage the resolved files
     run_command(["git", "add", "."], loading_msg="Staging resolved files...", ok_text="Conflict fixes staged.")

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -1,5 +1,6 @@
 from pygitgo.utils.cli_io import info, success, warning, error, confirm, banner, write
 from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.commands.git_core import ensure_inside_git_repository
 from pygitgo.commands.stash import (
     git_stash_apply, git_stash_clear, git_stash_drop,
     git_stash_list, git_stash_push
@@ -209,6 +210,7 @@ def delete_state(identifier=None):
 
 
 def state_operation(args):
+    ensure_inside_git_repository()
     alias = getattr(args, "action_alias", None)
     positional = getattr(args, "action", None)
 

--- a/src/pygitgo/commands/undo.py
+++ b/src/pygitgo/commands/undo.py
@@ -1,6 +1,7 @@
 from pygitgo.utils.cli_io import success, warning, info, confirm, danger, banner, write
 from pygitgo.commands.git_branch import get_current_branch
 from pygitgo.exceptions import GitCommandError, GitGoError
+from pygitgo.commands.git_core import ensure_inside_git_repository
 from pygitgo.utils.executor import run_command
 import sys
 
@@ -103,6 +104,7 @@ def undo_push():
 
 
 def undo_operation(args):
+    ensure_inside_git_repository()
     action = args.action
 
     success_flag = False

--- a/src/pygitgo/utils/banner.py
+++ b/src/pygitgo/utils/banner.py
@@ -1,10 +1,11 @@
-from pygitgo.commands.git_core import ensure_inside_git_repository, get_recent_commits
+from pygitgo.commands.git_core import is_git_repository, get_recent_commits
 from pygitgo.utils.colors import GREEN, YELLOW, CYAN, RESET
 from pygitgo.utils.update_checker import check_for_updates
 from pygitgo.commands.git_branch import get_current_branch
 from pygitgo.utils.executor import run_command
 from pygitgo.auth.account import get_user
 import shutil
+import sys
 
 
 def _safe(fn, default=None):
@@ -13,8 +14,8 @@ def _safe(fn, default=None):
     except Exception:
         return default
 
+
 def _format_sync():
-    """Human readable ahead/behind summary, or None if no upstream is tracked."""
     try:
         raw = run_command(["git", "rev-list", "--left-right", "--count", "HEAD...@{u}"])
     except Exception:
@@ -33,49 +34,57 @@ def _format_sync():
         return f"{YELLOW}{behind} behind{RESET}"
     return f"{YELLOW}{ahead} ahead, {behind} behind (diverged){RESET}"
 
+
 def show_banner():
     from pygitgo.main import get_version
-
-    ensure_inside_git_repository()
 
     username, email = get_user()
     username = username or "Not set"
     email = email or "Not set"
-    remote_url = _safe(lambda: run_command("git config --get remote.origin.url".split())) or "not set"
-    current_branch = _safe(get_current_branch) or "unknown"
-    sync_msg = _format_sync() or f"{YELLOW}no upstream{RESET}"
 
-    porcelain = run_command(["git", "status", "--porcelain"])
-    lines = [line for line in porcelain.splitlines() if line.strip()]
-    untracked = sum(1 for line in lines if line.startswith("??"))
-    modified = len(lines) - untracked
+    in_git = is_git_repository()
 
-    if modified == 0 and untracked == 0:
-        status_msg = f"{GREEN}clean{RESET}"
+    if in_git:
+        remote_url = _safe(lambda: run_command("git config --get remote.origin.url".split())) or "not set"
+        current_branch = _safe(get_current_branch) or "unknown"
+        sync_msg = _format_sync() or f"{YELLOW}no upstream{RESET}"
+
+        porcelain = _safe(lambda: run_command(["git", "status", "--porcelain"])) or ""
+        lines = [line for line in porcelain.splitlines() if line.strip()]
+        untracked = sum(1 for line in lines if line.startswith("??"))
+        modified = len(lines) - untracked
+
+        if modified == 0 and untracked == 0:
+            status_msg = f"{GREEN}clean{RESET}"
+        else:
+            parts = []
+            if modified:
+                parts.append(f"{modified} modified")
+            if untracked:
+                parts.append(f"{untracked} untracked")
+            status_msg = f"{YELLOW}{', '.join(parts)}{RESET}"
+
+        commits = _safe(lambda: get_recent_commits(number=1))
+        if commits:
+            c = commits[0]
+            latest = f"[{YELLOW}{c['hash']}{RESET}] {c['message']} ({CYAN}{c['date']}{RESET}) by {GREEN}{c['author']}{RESET}"
+        else:
+            latest = "no commits yet"
     else:
-        parts = []
-        if modified:
-            parts.append(f"{modified} modified")
-        if untracked:
-            parts.append(f"{untracked} untracked")
-        status_msg = f"{YELLOW}{', '.join(parts)}{RESET}"
-
-    commits = _safe(lambda: get_recent_commits(number=1))
-    if commits:
-        c = commits[0]
-        latest = f"[{YELLOW}{c['hash']}{RESET}] {c['message']} ({CYAN}{c['date']}{RESET}) by {GREEN}{c['author']}{RESET}"
-    else:
-        latest = "no commits yet"
+        remote_url = "not set"
+        current_branch = "none"
+        sync_msg = "none"
+        status_msg = f"{YELLOW}Not a git repository{RESET}"
+        latest = "Run 'gitgo init' or 'gitgo link' to start"
 
     version = get_version()
     cached = check_for_updates(version)
 
-    # auto-width box so it never overflows narrow terminals (e.g. Termux)
     width = max(46, min(shutil.get_terminal_size((80, 20)).columns - 2, 70))
-    top = "╭" + "─" * (width - 2) + "╮"
-    title = f"│{f' GitGo {version} '.center(width - 2)}│"
-    subtitle = f"│{'Your Fast Git Companion'.center(width - 2)}│"
-    bottom = "╰" + "─" * (width - 2) + "╯"
+    top = f"{GREEN}╭{'─' * (width - 2)}╮{RESET}"
+    title = f"{GREEN}│{RESET}{GREEN}{f' GitGo {version} '.center(width - 2)}{RESET}{GREEN}│{RESET}"
+    subtitle = f"{GREEN}│{RESET}{CYAN}{'Your Fast Git Companion'.center(width - 2)}{RESET}{GREEN}│{RESET}"
+    bottom = f"{GREEN}╰{'─' * (width - 2)}╯{RESET}"
 
     rows = [
         ("Identity", f"{username} <{email}>"),
@@ -93,12 +102,21 @@ def show_banner():
 
     out += [
         "",
-        "  PyPI     pypi.org/project/pygitgo",
-        "  GitHub   github.com/Huerte/GitGo",
-        "  Sponsor  github.com/sponsors/Huerte",
+        "  PyPI      pypi.org/project/pygitgo",
+        "  GitHub    github.com/Huerte/GitGo",
+        "  Sponsor   github.com/sponsors/Huerte",
     ]
     if cached:
         out += ["", str(cached)]
     out += ["", f"  Run {GREEN}`gitgo help`{RESET} to see available commands.", ""]
 
-    print("\n".join(out))
+    content = "\n".join(out)
+    try:
+        print(content)
+    except UnicodeEncodeError:
+        try:
+            sys.stdout.buffer.write((content + "\n").encode(sys.stdout.encoding or "utf-8", errors="replace"))
+        except Exception:
+            print(content.encode("ascii", errors="replace").decode("ascii"))
+
+

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -36,7 +36,7 @@ def test_format_sync_valid_cases(mocker, ahead, behind, expected):
 
 def test_show_banner_clean_status(mocker, capsys):
     mocker.patch("pygitgo.main.get_version", return_value="1.10.1")
-    mocker.patch("pygitgo.utils.banner.ensure_inside_git_repository")
+    mocker.patch("pygitgo.utils.banner.is_git_repository", return_value=True)
     mocker.patch("pygitgo.utils.banner.get_user", return_value=("Huerte", "huerte@example.com"))
     mocker.patch("pygitgo.utils.banner.get_current_branch", return_value="main")
     mocker.patch("pygitgo.utils.banner.check_for_updates", return_value=None)
@@ -79,7 +79,7 @@ def test_show_banner_clean_status(mocker, capsys):
 
 def test_show_banner_dirty_status(mocker, capsys):
     mocker.patch("pygitgo.main.get_version", return_value="1.10.1")
-    mocker.patch("pygitgo.utils.banner.ensure_inside_git_repository")
+    mocker.patch("pygitgo.utils.banner.is_git_repository", return_value=True)
     mocker.patch("pygitgo.utils.banner.get_user", return_value=(None, None))
     mocker.patch("pygitgo.utils.banner.get_current_branch", side_effect=Exception("no branch"))
     mocker.patch("pygitgo.utils.banner.check_for_updates", return_value="Update available: 1.10.2")
@@ -118,7 +118,7 @@ def test_show_banner_dirty_status(mocker, capsys):
 
 def test_show_banner_dirty_only_modified(mocker, capsys):
     mocker.patch("pygitgo.main.get_version", return_value="1.10.1")
-    mocker.patch("pygitgo.utils.banner.ensure_inside_git_repository")
+    mocker.patch("pygitgo.utils.banner.is_git_repository", return_value=True)
     mocker.patch("pygitgo.utils.banner.get_user", return_value=("user", "email"))
     mocker.patch("pygitgo.utils.banner.get_current_branch", return_value="main")
     mocker.patch("pygitgo.utils.banner.check_for_updates", return_value=None)
@@ -144,7 +144,7 @@ def test_show_banner_dirty_only_modified(mocker, capsys):
 
 def test_show_banner_dirty_only_untracked(mocker, capsys):
     mocker.patch("pygitgo.main.get_version", return_value="1.10.1")
-    mocker.patch("pygitgo.utils.banner.ensure_inside_git_repository")
+    mocker.patch("pygitgo.utils.banner.is_git_repository", return_value=True)
     mocker.patch("pygitgo.utils.banner.get_user", return_value=("user", "email"))
     mocker.patch("pygitgo.utils.banner.get_current_branch", return_value="main")
     mocker.patch("pygitgo.utils.banner.check_for_updates", return_value=None)
@@ -167,3 +167,17 @@ def test_show_banner_dirty_only_untracked(mocker, capsys):
     captured = capsys.readouterr().out
     assert "1 untracked" in captured
     assert "modified" not in captured
+
+def test_show_banner_non_git_repository(mocker, capsys):
+    mocker.patch("pygitgo.main.get_version", return_value="1.10.1")
+    mocker.patch("pygitgo.utils.banner.is_git_repository", return_value=False)
+    mocker.patch("pygitgo.utils.banner.get_user", return_value=("Huerte", "huerte@example.com"))
+    mocker.patch("pygitgo.utils.banner.check_for_updates", return_value=None)
+    
+    show_banner()
+    
+    captured = capsys.readouterr().out
+    assert "Identity" in captured
+    assert "Not a git repository" in captured
+    assert "Run 'gitgo init' or 'gitgo link' to start" in captured
+

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -20,48 +20,45 @@ def test_resolve_no_conflict(mock_path):
     with pytest.raises(GitGoError, match="No conflict resolution is currently in progress"):
         resolve_operation(args)
 
+@patch("pygitgo.commands.resolve.ensure_inside_git_repository")
 @patch("pygitgo.commands.resolve.run_command")
 @patch("pygitgo.commands.resolve.Path")
 @patch("pygitgo.commands.resolve.banner")
-def test_resolve_success(mock_banner, mock_path, mock_run):
+def test_resolve_success(mock_banner, mock_path, mock_run, mock_ensure_git):
     mock_path_instance = MagicMock()
     mock_path_instance.exists.return_value = True
     mock_path.return_value = mock_path_instance
     
-    mock_run.side_effect = ["", "", ""]
+    mock_run.side_effect = ["", ""]
     
     args = Namespace(abort=False)
     resolve_operation(args)
     
-    assert mock_run.call_count == 3
-    mock_run.assert_any_call(["git", "status", "--porcelain"])
+    mock_ensure_git.assert_called_once()
+    assert mock_run.call_count == 2
     mock_run.assert_any_call(["git", "add", "."], loading_msg="Staging resolved files...", ok_text="Conflict fixes staged.")
     mock_run.assert_any_call(["git", "rebase", "--continue"], loading_msg="Finishing sync...", extra_env={"GIT_EDITOR": "true"})
     
     mock_banner.assert_called_once()
 
-@patch("pygitgo.commands.resolve.run_command")
+@patch("pygitgo.commands.resolve.ensure_inside_git_repository")
 @patch("pygitgo.commands.resolve.Path")
-def test_resolve_status_error(mock_path, mock_run):
-    mock_path_instance = MagicMock()
-    mock_path_instance.exists.return_value = True
-    mock_path.return_value = mock_path_instance
-    
-    mock_run.side_effect = GitCommandError(["git", "status"])
+def test_resolve_status_error(mock_path, mock_ensure_git):
+    mock_ensure_git.side_effect = GitGoError("Not inside a git repository. Run 'gitgo init' or 'gitgo link' first.")
     
     args = Namespace(abort=False)
     with pytest.raises(GitGoError, match="Not inside a git repository"):
         resolve_operation(args)
 
+@patch("pygitgo.commands.resolve.ensure_inside_git_repository")
 @patch("pygitgo.commands.resolve.run_command")
 @patch("pygitgo.commands.resolve.Path")
-def test_resolve_still_conflicted(mock_path, mock_run):
+def test_resolve_still_conflicted(mock_path, mock_run, mock_ensure_git):
     mock_path_instance = MagicMock()
     mock_path_instance.exists.return_value = True
     mock_path.return_value = mock_path_instance
     
     mock_run.side_effect = [
-        "",
         "",
         GitCommandError(["git", "rebase", "--continue"], stderr="you must edit all merge conflicts", returncode=1)
     ]
@@ -70,15 +67,15 @@ def test_resolve_still_conflicted(mock_path, mock_run):
     with pytest.raises(GitGoError, match="You still have unresolved conflicts"):
         resolve_operation(args)
 
+@patch("pygitgo.commands.resolve.ensure_inside_git_repository")
 @patch("pygitgo.commands.resolve.run_command")
 @patch("pygitgo.commands.resolve.Path")
-def test_resolve_other_error(mock_path, mock_run):
+def test_resolve_other_error(mock_path, mock_run, mock_ensure_git):
     mock_path_instance = MagicMock()
     mock_path_instance.exists.return_value = True
     mock_path.return_value = mock_path_instance
     
     mock_run.side_effect = [
-        "",
         "",
         GitCommandError(["git", "rebase", "--continue"], stderr="some weird error occurred", returncode=1)
     ]


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / internal

## Changes

- `banner.py`: fixed unicode crashes on older Windows terminals, made all box borders consistently green, and added a friendly message when run outside a git repo instead of throwing an error.
- `gitgo push`, `pull`, `state`, `undo`, and `resolve`: added a check so running them outside a git repo prints a friendly error instead of crashing.
- `tests`: added new tests in `test_banner.py` for the non-git repo behavior and updated test mocks in `test_resolve.py`.

## Checklist

- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md)
- [ ] `README.md` updated (if a command was added or changed)
- [x] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)

