### PR TITLE
fix: auth, signing, and CLI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,27 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added robust Unicode print fallback for `show_banner` to prevent crashes on legacy Windows terminals.
+- Added `is_agent_loaded(key_path)` to check if an SSH key is currently held by the SSH agent before signing commits.
+- Added `get_remote_host(url)` to extract the hostname from any SSH or HTTPS remote URL.
+- Added new test cases: `test_get_signing_flags_agent_not_loaded`, `test_git_push_non_github_host_skips_conversion`, `test_sanitize_signing_config_ssh_format_agent_loaded`, `test_sanitize_signing_config_ssh_format_agent_not_loaded`.
 
 ### Fixed
 - Fixed target directory lock issues on Windows inside `gitgo init` on scaffolding failures by returning to the original directory before cleanup.
 - Safely handle non-git repository executions in `gitgo` banner by displaying human-readable status instead of throwing exception tracebacks.
 - Added git repository validation across commands (`push`, `pull`, `state`, `undo`, `resolve`) to output friendly error messages when executed outside a git repository.
 - Fixed misleading success banners from appearing when `pull` or `sync` operations did not actually fetch any new commits.
+- Fixed `gitgo push` silently failing with authentication errors on private Gitea and GitLab servers. HTTPS remotes on non-GitHub hosts are no longer converted to SSH, letting the user's existing HTTPS credentials work.
+- Fixed commit signing failures when the SSH agent is stopped between sessions. `_get_signing_flags` and `sanitize_signing_config` now check `is_agent_loaded` before enabling signing and disable it gracefully if the agent is empty.
+- Fixed `gitgo push` with no arguments only showing one of the two default values. Both the default branch and the default commit message are now shown before anything happens.
+- Fixed `gitgo state` letter aliases (`-l`, `-s`, `-o`, `-d`) causing confusion for new users. The aliases are removed. Use the full action words: `list`, `save`, `load`, `delete`.
 
 ### Changed
 - Expanded and cleaned test suite coverage (now at 93% total coverage) across commands and utility modules with clean, uncommented test cases.
 - Unified banner box borders to be consistently green across all CLI outputs.
+- Rewrote all CLI help text for `push`, `sync`, `link`, `jump`, `resolve`, `undo`, and `state` in plain English that is clear to users who are new to Git or non-native English speakers.
+- `ensure_known_host` is now host-aware and works for any server. The existing `ensure_github_known_host` alias is kept for backward compatibility.
+- `convert_https_to_ssh` now matches any hostname, not just `github.com`.
+- Updated `README.md`: documented the both-defaults behavior for `gitgo push`, removed state aliases from docs, updated descriptions for `sync`, `link`, `jump`, `resolve`, and `undo`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added robust Unicode print fallback for `show_banner` to prevent crashes on legacy Windows terminals.
-- Added `is_agent_loaded(key_path)` to check if an SSH key is currently held by the SSH agent before signing commits.
+- Added `is_agent_loaded(key_path)` to check if an SSH key is currently held by the SSH agent.
 - Added `get_remote_host(url)` to extract the hostname from any SSH or HTTPS remote URL.
-- Added new test cases: `test_get_signing_flags_agent_not_loaded`, `test_git_push_non_github_host_skips_conversion`, `test_sanitize_signing_config_ssh_format_agent_loaded`, `test_sanitize_signing_config_ssh_format_agent_not_loaded`.
 
 ### Fixed
 - Fixed target directory lock issues on Windows inside `gitgo init` on scaffolding failures by returning to the original directory before cleanup.
@@ -20,7 +19,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added git repository validation across commands (`push`, `pull`, `state`, `undo`, `resolve`) to output friendly error messages when executed outside a git repository.
 - Fixed misleading success banners from appearing when `pull` or `sync` operations did not actually fetch any new commits.
 - Fixed `gitgo push` silently failing with authentication errors on private Gitea and GitLab servers. HTTPS remotes on non-GitHub hosts are no longer converted to SSH, letting the user's existing HTTPS credentials work.
-- Fixed commit signing failures when the SSH agent is stopped between sessions. `_get_signing_flags` and `sanitize_signing_config` now check `is_agent_loaded` before enabling signing and disable it gracefully if the agent is empty.
+- Fixed commit signing configuration checking in `sanitize_signing_config` to verify the SSH key file exists on disk, disabling commit signing gracefully if it is missing to prevent failures.
 - Fixed `gitgo push` with no arguments only showing one of the two default values. Both the default branch and the default commit message are now shown before anything happens.
 - Fixed `gitgo state` letter aliases (`-l`, `-s`, `-o`, `-d`) causing confusion for new users. The aliases are removed. Use the full action words: `list`, `save`, `load`, `delete`.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ gitgo new my-app python
 ## Features
 
 - **Single commands for linking, pushing, and stashing.** No more chaining five commands together.
-- **Seamless Sync:** Run `sync` to pull the latest updates (with rebase), commit your staged files, and push in one go.
+- **Seamless Sync:** Run `sync` to pull the latest changes, commit your work, and push in one command.
 - **Smart CLI UI:** Modern box-drawing banners, color-coded output, and automatic terminal capability detection (respects `NO_COLOR` and Windows VT limitations).
 - **Quickstart with `new`:** One command to scaffold your project, create the GitHub repo, and push it. No switching tabs, no manual steps.
 - **Project scaffolding with `init`:** Generates a language-specific project structure with a `.gitignore` from GitHub's official templates. Supports Python, Node, Rust, Go, C#, and more.
@@ -75,7 +75,7 @@ gitgo new my-app python
 - **Conflict resolution with `resolve`:** Finish a pull after fixing a merge conflict. Verifies the conflict markers are actually gone before staging and completing it. Back out anytime with `resolve --abort`.
 - **Commit history with `log`:** View a beautifully color-coded and structured commit history.
 - **Branch switching with `jump`:** Stashes your uncommitted work, moves to the target branch, syncs with main, and pops the stash. If a merge conflict occurs, the Try-and-Revert engine offers to roll the whole operation back.
-- **State management:** Named, indexed stash. Run `state list` to see what you saved. No more `stash@{2}` archaeology.
+- **Snapshot management:** Named, numbered interface over `git stash`. Run `state list` to see what you saved. No more `stash@{2}` archaeology.
 - **Custom defaults:** Store your preferred branch name and default commit message. GitGo picks them up on every run.
 - **Auto-update checker:** Checks PyPI for newer versions in a background thread. Results are cached for 7 days so startup isn't delayed.
 - **SSH auto-setup & signing:** Generates an `ed25519` key, loads it into `ssh-agent`, opens your GitHub SSH settings page, and automatically signs all future commits for the verified badge.
@@ -324,6 +324,16 @@ gitgo push -s [branch] [message]   # interactively select files to stage
 | `-n`, `--new` | Create a new branch before pushing |
 | `-s`, `--select` | Interactively select which files to include in the push |
 
+**How arguments work:**
+- Two arguments: first is the branch, second is the commit message.
+- One argument: if it matches an existing branch, it is used as the branch; otherwise it is used as the commit message and the current branch is used.
+- No arguments: GitGo uses your current branch and the configured default message. Both defaults are shown before anything happens, for example:
+  ```
+  No branch given. Using: 'main'
+  No commit message given. Using: 'chore: new changes applied'
+  ```
+  You can change these defaults with `gitgo config set default-branch` and `gitgo config set default-message`.
+
 If there are no new changes but unpushed commits exist, GitGo detects this and pushes without creating an empty commit.
 
 ### `gitgo pull`
@@ -337,7 +347,7 @@ gitgo pull <branch>    # Pull updates from a specific branch
 
 ### `gitgo sync`
 
-Synchronizes your branch with the remote. Pulls latest updates with `--rebase` and `--autostash`, commits staged files, and pushes everything.
+Pulls the latest changes with `--rebase` and `--autostash`, commits your work, then pushes everything in one step.
 
 ```bash
 gitgo sync [message]
@@ -345,15 +355,15 @@ gitgo sync [message]
 
 ### `gitgo link`
 
-Initializes a Git repository, connects it to a remote, and pushes. Works on already-initialized repos and handles unrelated histories.
+Connects a local project to a remote repository. Initializes Git if needed, stages everything, commits, and pushes. Works on already-initialized repos too, and handles unrelated histories.
 
 ```bash
-gitgo link <github_repo_url> [commit_message]
+gitgo link <repo_url> [commit_message]
 ```
 
 ### `gitgo jump`
 
-Switches branches with uncommitted work in progress. Stashes changes, moves to the target branch, pulls from main, and pops the stash. If the pop triggers a merge conflict, the Try-and-Revert engine offers to abort the entire operation and restore the repo to the state it was in before the command ran.
+Switches to another branch while saving your current work automatically. Stashes your changes, moves to the target branch, pulls from main, then restores your work. If restoring causes a conflict, the Try-and-Revert engine offers to cancel the whole operation and put everything back.
 
 ```bash
 gitgo jump <branch>
@@ -366,25 +376,23 @@ Undo recent actions with subcommands named for what they undo.
 ```bash
 gitgo undo commit    # Undo the last commit without losing files
 gitgo undo add       # Unstage files
-gitgo undo changes   # Permanently discard all new files and uncommitted edits
+gitgo undo changes   # DANGER (destructive): permanently discard all uncommitted edits
 gitgo undo link      # Remove the remote and undo the initial commit
-gitgo undo push      # DANGER: Revert the last push with a force-push
+gitgo undo push      # DANGER (destructive): revert the last push with a force-push
 gitgo undo pull      # Revert the branch to its state before the last pull
 ```
 
 ### `gitgo state`
 
-Named, indexed interface over `git stash`.
+Save and restore snapshots of your work-in-progress. Built on top of `git stash` with named saves and numbered access.
 
 ```bash
-gitgo state list              # show all saved states
+gitgo state list              # show all saved snapshots
 gitgo state save [name]       # save current work (default name: Auto-Save)
-gitgo state load [id]         # restore a state by index
-gitgo state delete [id]       # delete a state by index
-gitgo state delete -a         # delete all saved states
+gitgo state load [id]         # restore a snapshot by its number
+gitgo state delete [id]       # delete a snapshot by its number
+gitgo state delete -a         # delete all saved snapshots
 ```
-
-*Short aliases:* `-l`, `-s`, `-o`, `-d`
 
 ### `gitgo log`
 

--- a/src/pygitgo/auth/account.py
+++ b/src/pygitgo/auth/account.py
@@ -85,18 +85,11 @@ def sanitize_signing_config():
         fmt = ""
 
     if fmt == "ssh":
-        # Check that the key file exists and the agent has it loaded.
-        from pygitgo.auth.ssh_utils import get_ssh_key_path, is_agent_loaded
+        from pygitgo.auth.ssh_utils import get_ssh_key_path
         key_path = get_ssh_key_path()
-        if key_path.exists() and is_agent_loaded(key_path):
-            # Signing is properly configured, nothing to fix.
+        if key_path.exists():
             return
-
-        if not key_path.exists():
-            warning("SSH signing key file not found. Disabling commit signing to prevent failures.")
-        else:
-            warning("SSH signing key is not loaded in the agent. Disabling commit signing to prevent failures.")
-            info("Run 'gitgo user login' to reload your key.")
+        warning("SSH signing key file not found. Disabling commit signing to prevent failures.")
     else:
         warning("Commit signing is on but no GPG key is configured.")
         warning("Disabling global commit signing to prevent failures.")

--- a/src/pygitgo/auth/account.py
+++ b/src/pygitgo/auth/account.py
@@ -75,29 +75,38 @@ def sanitize_signing_config():
         gpgsign = run_command(["git", "config", "--global", "commit.gpgsign"]).strip().lower()
     except GitCommandError:
         return
-    
+
     if gpgsign != "true":
         return
-    
+
     try:
         fmt = run_command(["git", "config", "--global", "gpg.format"]).strip().lower()
     except GitCommandError:
         fmt = ""
 
     if fmt == "ssh":
-        return
-    
-    warning("Detected 'commit.gpgsign=true' with no GPG key configured.")
-    warning("Disabling global GPG signing to prevent commit failures.")
+        # Check that the key file exists and the agent has it loaded.
+        from pygitgo.auth.ssh_utils import get_ssh_key_path, is_agent_loaded
+        key_path = get_ssh_key_path()
+        if key_path.exists() and is_agent_loaded(key_path):
+            # Signing is properly configured, nothing to fix.
+            return
+
+        if not key_path.exists():
+            warning("SSH signing key file not found. Disabling commit signing to prevent failures.")
+        else:
+            warning("SSH signing key is not loaded in the agent. Disabling commit signing to prevent failures.")
+            info("Run 'gitgo user login' to reload your key.")
+    else:
+        warning("Commit signing is on but no GPG key is configured.")
+        warning("Disabling global commit signing to prevent failures.")
 
     try:
         run_command(["git", "config", "--global", "--unset", "gpg.program"])
     except GitCommandError:
         pass
-    
+
     try:
         run_command(["git", "config", "--global", "--unset", "commit.gpgsign"])
     except GitCommandError:
         pass
-    
-

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -3,6 +3,7 @@ from pygitgo.utils.cli_io import info, success, warning
 from pygitgo.utils.platform import get_platform
 from pygitgo.utils.executor import run_command
 from pathlib import Path
+from typing import Optional
 import subprocess
 import time
 import os
@@ -15,36 +16,56 @@ _cached_ssh_response = None
 _cache_populated = False
 
 
-def ensure_github_known_host():
+def get_remote_host(url: str) -> Optional[str]:
+    """Return the hostname from an SSH or HTTPS remote URL."""
+    url = url.strip()
+    # git@host:owner/repo.git
+    ssh_match = re.match(r"git@([^:]+):", url)
+    if ssh_match:
+        return ssh_match.group(1)
+    # https://host/owner/repo or http://host/owner/repo
+    https_match = re.match(r"https?://([^/]+)", url)
+    if https_match:
+        return https_match.group(1)
+    return None
+
+
+def ensure_known_host(host: str = "github.com"):
+    """Add a host to known_hosts if it is not already there."""
     known_hosts = Path.home() / ".ssh" / "known_hosts"
     known_hosts.parent.mkdir(parents=True, exist_ok=True)
 
     try:
         if known_hosts.exists():
             with open(known_hosts, "r") as f:
-                if "github.com" in f.read():
-                    return 
+                if host in f.read():
+                    return
     except Exception:
         pass
 
-    info("Adding GitHub to known_hosts...")
+    info(f"Adding {host} to known_hosts...")
     try:
-        result = run_command(["ssh-keyscan", "-H", "github.com"], return_complete=True)
-    
-        if result.stdout and "github.com" in result.stdout:
+        result = run_command(["ssh-keyscan", "-H", host], return_complete=True)
+        if result.stdout and host in result.stdout:
             with open(known_hosts, "a") as f:
                 f.write(result.stdout)
                 if not result.stdout.endswith("\n"):
                     f.write("\n")
-            success("GitHub added to known_hosts.")
+            success(f"{host} added to known_hosts.")
     except GitCommandError:
-        warning("Could not automatically add GitHub to known_hosts. You might be prompted.")
+        warning(f"Could not automatically add {host} to known_hosts. You might be prompted.")
 
 
-def _get_github_ssh_response():
+# Keep the old name so existing callers do not break.
+def ensure_github_known_host():
+    ensure_known_host("github.com")
+
+
+def _get_ssh_response(host: str = "github.com"):
+    """Test SSH connectivity to the given host."""
     try:
         result = subprocess.run(
-            ["ssh", "-T", "-o", "BatchMode=yes", "git@github.com"],
+            ["ssh", "-T", "-o", "BatchMode=yes", f"git@{host}"],
             capture_output=True, text=True,
             timeout=SSH_TIMEOUT_SECONDS, stdin=subprocess.DEVNULL,
         )
@@ -54,6 +75,11 @@ def _get_github_ssh_response():
         return "", True, None
     except OSError as e:
         return "", False, str(e)
+
+
+# Keep module-level cache for GitHub only (used by login flow).
+def _get_github_ssh_response():
+    return _get_ssh_response("github.com")
 
 
 def _get_cached_ssh_response():
@@ -69,47 +95,55 @@ def clear_ssh_cache():
     _cached_ssh_response = None
     _cache_populated = False
 
-from typing import Optional
+
 def classify_connection_error(raw_output: str, timed_out: bool, os_error: Optional[str]) -> str:
-    """Return a specific, human-readable cause string based on the SSH response."""
+    """Return a short, plain-English reason for a connection failure."""
     if timed_out:
-        return "Connection timed out. GitHub SSH port (22) may be blocked by your network or firewall."
+        return "Connection timed out. Port 22 may be blocked by your network or firewall."
     if os_error:
-        return f"Could not launch the SSH client: {os_error}"
+        return f"Could not start SSH: {os_error}"
     if not raw_output:
-        return "No response from GitHub. Check your internet connection."
+        return "No response from the server. Check your internet connection."
     if "Permission denied" in raw_output:
-        return "Permission denied. The SSH key has not been added to your GitHub account, or it was added incorrectly."
+        return "Permission denied. Your SSH key was not accepted by the server."
     if "Connection refused" in raw_output:
         return "Connection refused on port 22. Try a network without strict firewall rules."
     if "Host key verification failed" in raw_output:
-        return "Host key verification failed. Run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts"
+        return "Host key check failed. Run: ssh-keyscan -H <host> >> ~/.ssh/known_hosts"
     if "Could not resolve hostname" in raw_output:
-        return "DNS lookup failed. You may be offline or behind a restrictive proxy."
-    # Return the raw SSH message so users see the actual problem.
+        return "DNS lookup failed. You may be offline or behind a proxy."
     return raw_output.strip() or "Unknown SSH error."
 
 
-def check_connection(ok_text=None, fail_text=None):
+def check_connection(ok_text=None, fail_text=None, host: str = "github.com"):
+    """Check SSH connectivity to a given host. Defaults to github.com."""
     from yaspin import yaspin
     import sys
 
-    ensure_github_known_host()
+    ensure_known_host(host)
 
-    kwargs = {"text": "Verifying GitHub connection..."}
+    kwargs = {"text": f"Checking connection to {host}..."}
     if sys.stdout.isatty():
         kwargs["color"] = "cyan"
     spinner = yaspin(**kwargs)
     spinner.start()
 
-    raw_output, timed_out, os_error = _get_cached_ssh_response()
-    connected = not timed_out and not os_error and "successfully authenticated" in raw_output
+    if host == "github.com":
+        raw_output, timed_out, os_error = _get_cached_ssh_response()
+    else:
+        raw_output, timed_out, os_error = _get_ssh_response(host)
+
+    connected = (
+        not timed_out
+        and not os_error
+        and "successfully authenticated" in raw_output
+    )
 
     if connected:
-        spinner.text = ok_text or "GitHub connection verified."
+        spinner.text = ok_text or f"Connected to {host}."
         spinner.ok("✔")
     else:
-        spinner.text = fail_text or "Could not connect to GitHub."
+        spinner.text = fail_text or f"Could not connect to {host}."
         spinner.fail("✖")
 
     return connected
@@ -124,21 +158,39 @@ def get_github_username():
             pass
     return None
 
+
 def get_ssh_key_path():
     return Path.home() / ".ssh" / "id_ed25519"
+
+
+def is_agent_loaded(key_path: Path) -> bool:
+    """Return True if the given key is currently loaded in the SSH agent."""
+    try:
+        result = subprocess.run(
+            ["ssh-add", "-l"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout:
+            # Check by key file path or by fingerprint presence.
+            key_str = str(key_path)
+            return key_str in result.stdout
+        return False
+    except Exception:
+        return False
+
 
 def generate_ssh_key(email):
     if not email or "@" not in email or "." not in email:
         raise GitGoError("Invalid email address provided for SSH key generation.")
-    
+
     key_path = get_ssh_key_path()
     if not key_path.parent.exists():
         key_path.parent.mkdir(parents=True)
-    
+
     if key_path.exists():
         from pygitgo.utils.cli_io import confirm
         if not confirm(f"SSH key {key_path} already exists. Overwrite it? (y/n): ", destructive=True):
-            raise GitGoError("SSH key generation aborted. Please back up your existing key or configure it manually.")
+            raise GitGoError("SSH key generation canceled. Back up your existing key or configure it manually.")
         os.remove(key_path)
     if (key_path.parent / f"{key_path.name}.pub").exists():
         os.remove(key_path.parent / f"{key_path.name}.pub")
@@ -155,29 +207,32 @@ def generate_ssh_key(email):
         run_command(command=command)
     except GitCommandError as e:
         raise GitGoError(
-            "\nFailed to generate SSH key. Is 'ssh-keygen' installed on your system?\n"
+            "\nFailed to generate SSH key. Is 'ssh-keygen' installed?\n"
             f"Details: {e}"
         )
-    
+
     ensure_ssh_agent(key_path, quiet=True)
-    
+
     return key_path
 
 
-def convert_https_to_ssh(url):    
-    pattern = r'^https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$'
-    match = re.match(pattern, url.strip())
-    
+def convert_https_to_ssh(url: str) -> Optional[str]:
+    """Convert an HTTPS remote URL to SSH format. Works for any hostname."""
+    url = url.strip()
+    # Match https://host/owner/repo or https://host/owner/repo.git
+    pattern = r"^https?://([^/]+)/([^/]+)/([^/]+?)(?:\.git)?/?$"
+    match = re.match(pattern, url)
     if match:
-        owner = match.group(1)
-        repo = match.group(2)
-        return f"git@github.com:{owner}/{repo}.git"
-    
+        host = match.group(1)
+        owner = match.group(2)
+        repo = match.group(3)
+        return f"git@{host}:{owner}/{repo}.git"
     return None
 
 
 def is_ssh_url(url):
     return url.strip().startswith("git@")
+
 
 def _try_ssh_add(key_path):
     try:
@@ -186,10 +241,11 @@ def _try_ssh_add(key_path):
     except (GitCommandError, OSError):
         return False
 
+
 def ensure_ssh_agent(key_path, quiet=False):
     if _try_ssh_add(key_path):
         return True
-    
+
     if get_platform() == "windows":
         try:
             subprocess.run(
@@ -203,12 +259,13 @@ def ensure_ssh_agent(key_path, quiet=False):
 
         if _try_ssh_add(key_path):
             return True
-        
+
         if not quiet:
             warning("SSH agent is not running. Key may not persist across sessions.")
-            info("To fix this permanently, run in PowerShell (as Administrator):")
+            info("To fix this, run PowerShell as Administrator and type:")
             info("  Set-Service ssh-agent -StartupType Automatic")
             info("  Start-Service ssh-agent")
+            info("Then run 'gitgo user login' again.")
 
     else:
         if not quiet:
@@ -216,4 +273,3 @@ def ensure_ssh_agent(key_path, quiet=False):
             info("Run:  eval $(ssh-agent) && ssh-add")
 
     return False
-    

--- a/src/pygitgo/commands/git_core.py
+++ b/src/pygitgo/commands/git_core.py
@@ -1,4 +1,4 @@
-from pygitgo.auth.ssh_utils import convert_https_to_ssh, get_ssh_key_path, is_ssh_url, check_connection, is_agent_loaded, get_remote_host
+from pygitgo.auth.ssh_utils import convert_https_to_ssh, get_ssh_key_path, is_ssh_url, check_connection, get_remote_host
 from pygitgo.exceptions import GitGoError, GitCommandError
 from pygitgo.auth.account import sanitize_signing_config
 from pygitgo.commands.git_remote import handle_rebase
@@ -77,10 +77,6 @@ def get_recent_commits(number=5, branch=None):
 def _get_signing_flags():
     key_path = get_ssh_key_path()
     if not key_path.exists():
-        return []
-    if not is_agent_loaded(key_path):
-        warning("SSH key is not loaded in the agent. Skipping commit signing this time.")
-        warning("Run 'gitgo user login' to load your key and re-enable signing.")
         return []
     return [
         "-c", "gpg.format=ssh",

--- a/src/pygitgo/commands/git_core.py
+++ b/src/pygitgo/commands/git_core.py
@@ -1,4 +1,4 @@
-from pygitgo.auth.ssh_utils import convert_https_to_ssh, get_ssh_key_path, is_ssh_url, check_connection
+from pygitgo.auth.ssh_utils import convert_https_to_ssh, get_ssh_key_path, is_ssh_url, check_connection, is_agent_loaded, get_remote_host
 from pygitgo.exceptions import GitGoError, GitCommandError
 from pygitgo.auth.account import sanitize_signing_config
 from pygitgo.commands.git_remote import handle_rebase
@@ -78,11 +78,14 @@ def _get_signing_flags():
     key_path = get_ssh_key_path()
     if not key_path.exists():
         return []
+    if not is_agent_loaded(key_path):
+        warning("SSH key is not loaded in the agent. Skipping commit signing this time.")
+        warning("Run 'gitgo user login' to load your key and re-enable signing.")
+        return []
     return [
         "-c", "gpg.format=ssh",
         "-c", f"user.signingkey={key_path}",
     ]
-
 
 
 def git_commit(commit_message, loading_msg="Committing changes...", skip_staging=False, ok_text=None):
@@ -139,10 +142,22 @@ def git_push(branch, ok_text=None):
     except GitCommandError:
         remote_url = None
 
-    if remote_url and not is_ssh_url(remote_url) and check_connection():
-        ssh_url = convert_https_to_ssh(remote_url)
-        if ssh_url:
-            run_command(["git", "remote", "set-url", "origin", ssh_url], loading_msg="Converting remote from HTTPS to SSH for secure push...", ok_text=f"Remote updated to: {ssh_url}")
+    if remote_url and not is_ssh_url(remote_url):
+        # Only attempt SSH conversion if the remote host is github.com and
+        # GitHub SSH is working. For other hosts (Gitea, GitLab, etc.) we
+        # leave the URL as-is so HTTPS credentials are used instead.
+        remote_host = get_remote_host(remote_url)
+        if remote_host == "github.com" and check_connection():
+            ssh_url = convert_https_to_ssh(remote_url)
+            if ssh_url:
+                run_command(
+                    ["git", "remote", "set-url", "origin", ssh_url],
+                    loading_msg="Converting remote from HTTPS to SSH...",
+                    ok_text=f"Remote updated to: {ssh_url}"
+                )
+        elif remote_host and remote_host != "github.com":
+            from pygitgo.utils.cli_io import info as _info
+            _info(f"Remote host is '{remote_host}'. Keeping HTTPS URL (SSH conversion is for GitHub only).")
 
     try:
         run_command(["git", "push", "-u", "origin", branch], loading_msg=f"Pushing to remote branch '{branch}'...", ok_text=ok_text, err_text="Push failed: verify your remote URL and SSH key, then try again.")

--- a/src/pygitgo/commands/push.py
+++ b/src/pygitgo/commands/push.py
@@ -100,7 +100,11 @@ def push_operation(args):
 
         if not message:
             message = get_config("default-message", "chore: new changes applied")
-            info(f"No commit message provided. Using default: '{message}'\n")
+            if not args.branch:  # no arguments at all
+                info(f"No branch given. Using: '{branch}'")
+                info(f"No commit message given. Using: '{message}'\n")
+            else:
+                info(f"No commit message given. Using: '{message}'\n")
 
         if select:
             files = get_changed_files()

--- a/src/pygitgo/commands/state.py
+++ b/src/pygitgo/commands/state.py
@@ -211,15 +211,7 @@ def delete_state(identifier=None):
 
 def state_operation(args):
     ensure_inside_git_repository()
-    alias = getattr(args, "action_alias", None)
-    positional = getattr(args, "action", None)
-
-    if alias and positional and alias != positional:
-        raise GitGoError(
-            f"Conflicting actions: '{positional}' and '{alias}'. Use one or the other."
-        )
-
-    action = alias or positional
+    action = getattr(args, "action", None)
     identifier = getattr(args, "identifier", None)
 
     if getattr(args, "all", False):
@@ -230,7 +222,7 @@ def state_operation(args):
         identifier = "-a"
 
     if not action:
-        raise GitGoError("Missing action. Use: list, save, load, delete (or -l, -s, -o, -d).")
+        raise GitGoError("Missing action. Use one of: list, save, load, delete.")
 
     if action == "list":
         state_list()
@@ -241,4 +233,4 @@ def state_operation(args):
     elif action == "delete":
         delete_state(identifier)
     else:
-        raise GitGoError(f"Unknown state operation: {action}")
+        raise GitGoError(f"Unknown state action: {action}")

--- a/src/pygitgo/main.py
+++ b/src/pygitgo/main.py
@@ -71,20 +71,20 @@ def main():
 
     jump_parser = _add_subcommand(
         subparsers,
-        "jump", 
-        help="Safely switch branches with try-and-revert",
+        "jump",
+        help="Switch to another branch, saving your current work automatically if needed",
         epilog="Examples:\n  gitgo jump feature/login          Switch to 'feature/login' branch"
     )
     jump_parser.add_argument("branch", help="The name of the branch to jump to")
 
     link_parser = _add_subcommand(
         subparsers,
-        "link", 
-        help="Init, commit, and link to a remote repo",
+        "link",
+        help="Connect a local project to a remote repository (initializes if needed)",
         epilog=(
             "Examples:\n"
-            "  gitgo link https://github.com/user/repo.git               Link to a remote repo\n"
-            "  gitgo link https://github.com/user/repo.git 'First commit' Link with custom commit message"
+            "  gitgo link https://github.com/user/repo.git               Connect to a remote repo\n"
+            "  gitgo link https://github.com/user/repo.git 'First commit' Connect with a custom first commit message"
         )
     )
     link_parser.add_argument("url", help="The GitHub repository URL to link")
@@ -93,12 +93,13 @@ def main():
     push_parser = _add_subcommand(
         subparsers,
         "push",
-        help="Commit and push branch to remote",
+        help="Commit and push changes to remote",
         epilog=(
             "Examples:\n"
-            "  gitgo push                        Push current branch with default message\n"
-            "  gitgo push main 'fix auth bug'    Push to main with a custom message\n"
+            "  gitgo push                        Push current branch using defaults (shows which defaults are used)\n"
+            "  gitgo push main 'fix auth bug'    Push to 'main' with a specific message\n"
             "  gitgo push 'fix auth bug'         Push current branch with a custom message\n"
+            "                                    (a single argument that is not a branch name is treated as the message)\n"
             "  gitgo push -n feature/login 'add login'   Create new branch and push\n"
             "  gitgo push -s main 'fix bug'      Pick which files to include before pushing"
         )
@@ -111,14 +112,14 @@ def main():
     state_parser = _add_subcommand(
         subparsers,
         "state",
-        help="Manage saved working states (stashes)",
+        help="Temporarily save and restore your work-in-progress",
         epilog=(
             "Examples:\n"
-            "  gitgo state list                  Show all saved states\n"
+            "  gitgo state list                  Show all saved snapshots\n"
             "  gitgo state save 'halfway done'   Save current work with a name\n"
-            "  gitgo state load 1                Restore state by ID\n"
-            "  gitgo state delete 1              Delete a specific state\n"
-            "  gitgo state delete -a             Delete all saved states"
+            "  gitgo state load 1                Restore a snapshot by its number\n"
+            "  gitgo state delete 1              Delete a specific snapshot\n"
+            "  gitgo state delete -a             Delete all snapshots"
         )
     )
     state_parser.add_argument(
@@ -133,18 +134,12 @@ def main():
         "identifier",
         nargs="?",
         default=None,
-        help="Optional name or ID"
+        help="Optional name or number"
     )
-    _alias_group = state_parser.add_mutually_exclusive_group()
-    _alias_group.add_argument("-l", dest="action_alias", action="store_const", const="list",   help="Alias for 'list'")
-    _alias_group.add_argument("-s", dest="action_alias", action="store_const", const="save",   help="Alias for 'save'")
-    _alias_group.add_argument("-o", dest="action_alias", action="store_const", const="load",   help="Alias for 'load'")
-    _alias_group.add_argument("-d", dest="action_alias", action="store_const", const="delete", help="Alias for 'delete'")
-
     state_parser.add_argument(
         "-a", "--all",
         action="store_true",
-        help="Apply action to all states (e.g., delete all)"
+        help="Apply action to all snapshots (for example: delete all)"
     )
     
     user_parser = _add_subcommand(
@@ -176,22 +171,22 @@ def main():
 
     undo_parser = _add_subcommand(
         subparsers,
-        "undo", 
-        help="Safely undo mistakes", 
+        "undo",
+        help="Safely undo mistakes",
         epilog=(
             "Examples:\n"
-            "  gitgo undo commit       Undo your last commit (your files are safe)\n"
+            "  gitgo undo commit       Undo your last commit (your files stay safe)\n"
             "  gitgo undo add          Undo 'git add' (files are no longer ready to commit)\n"
-            "  gitgo undo changes      DANGER: Throw away all new changes and start fresh\n"
-            "  gitgo undo link         Remove the remote and undo the initial commit\n"
-            "  gitgo undo push         DANGER: Revert the last push with a force-push\n"
-            "  gitgo undo pull         Revert the branch to its state before the last pull"
+            "  gitgo undo changes      DANGER: Throw away all new changes permanently\n"
+            "  gitgo undo link         Remove the remote and undo the first commit\n"
+            "  gitgo undo push         DANGER: Undo the last push with a force-push\n"
+            "  gitgo undo pull         Revert the branch to how it was before the last pull"
         )
     )
     undo_parser.add_argument(
-        "action", 
-        choices=["commit", "add", "changes", "link", "push", "pull"], 
-        help="What to undo: 'commit', 'add', 'changes', 'link', 'push', or 'pull'"
+        "action",
+        choices=["commit", "add", "changes", "link", "push", "pull"],
+        help="What to undo: 'commit', 'add', 'changes' (destructive), 'link', 'push' (destructive), or 'pull'"
     )
 
     pull_parser = _add_subcommand(
@@ -208,13 +203,13 @@ def main():
 
     resolve_parser = _add_subcommand(
         subparsers,
-        "resolve", 
-        help="Resolve a paused sync after fixing a merge conflict",
-        description="Automatically stages your resolved files and finishes the active merge conflict, bypassing the text editor.",
+        "resolve",
+        help="Finish a merge conflict after you have fixed the files",
+        description="Run this after you fix the conflicting lines in your files. GitGo will stage the fixed files and complete the merge automatically.",
         epilog=(
             "Examples:\n"
-            "  gitgo resolve                     Finish merge conflict after fixing files\n"
-            "  gitgo resolve --abort             Cancel the merge/rebase and revert to pre-pull state"
+            "  gitgo resolve                     Finish a merge conflict after fixing your files\n"
+            "  gitgo resolve --abort             Cancel and go back to how things were before the conflict"
         )
     )
     resolve_parser.add_argument("--abort", action="store_true", help="Abort the current merge/rebase and revert to the pre-pull state")
@@ -351,10 +346,10 @@ def main():
     sync_parser = _add_subcommand(
         subparsers,
         "sync",
-        help="Download updates, save your work, and upload in one step (pull, commit, push)",
+        help="Pull the latest changes, commit your work, and push, all at once",
         epilog=(
             "Examples:\n"
-            "  gitgo sync                        Sync with default commit message\n"
+            "  gitgo sync                        Sync with the default commit message\n"
             "  gitgo sync 'Fix navbar'           Sync and commit with a custom message\n"
         )
     )

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -86,33 +86,31 @@ def test_sanitize_signing_config_not_configured(mocker):
     fake_run.assert_called_once_with(["git", "config", "--global", "commit.gpgsign"])
 
 
-def test_sanitize_signing_config_ssh_format_agent_loaded(mocker):
-    """When gpg.format=ssh and the key is loaded in the agent, signing stays enabled."""
+def test_sanitize_signing_config_ssh_format_key_exists(mocker):
+    """When gpg.format=ssh and the key file exists, signing is left on."""
     fake_run = mocker.patch("pygitgo.auth.account.run_command", side_effect=["true", "ssh"])
     mock_key = mocker.MagicMock()
     mock_key.exists.return_value = True
     mocker.patch("pygitgo.auth.ssh_utils.get_ssh_key_path", return_value=mock_key)
-    mocker.patch("pygitgo.auth.ssh_utils.is_agent_loaded", return_value=True)
     sanitize_signing_config()
     assert fake_run.call_count == 2
     fake_run.assert_any_call(["git", "config", "--global", "commit.gpgsign"])
     fake_run.assert_any_call(["git", "config", "--global", "gpg.format"])
 
 
-def test_sanitize_signing_config_ssh_format_agent_not_loaded(mocker):
-    """When gpg.format=ssh but the agent does not have the key, signing is disabled."""
+def test_sanitize_signing_config_ssh_format_key_missing(mocker):
+    """When gpg.format=ssh but the key file is missing, signing is disabled."""
     fake_run = mocker.patch(
         "pygitgo.auth.account.run_command",
         side_effect=["true", "ssh", None, None]
     )
     mock_key = mocker.MagicMock()
-    mock_key.exists.return_value = True
+    mock_key.exists.return_value = False
     mocker.patch("pygitgo.auth.ssh_utils.get_ssh_key_path", return_value=mock_key)
-    mocker.patch("pygitgo.auth.ssh_utils.is_agent_loaded", return_value=False)
     fake_warning = mocker.patch("pygitgo.auth.account.warning")
-    mocker.patch("pygitgo.auth.account.info")
     sanitize_signing_config()
     assert fake_warning.call_count >= 1
+
 
 def test_sanitize_signing_config_unset_gpg_program(mocker):
     fake_run = mocker.patch("pygitgo.auth.account.run_command", side_effect=["true", "openpgp", None, None])

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -86,13 +86,33 @@ def test_sanitize_signing_config_not_configured(mocker):
     fake_run.assert_called_once_with(["git", "config", "--global", "commit.gpgsign"])
 
 
-def test_sanitize_signing_config_ssh_format(mocker):
+def test_sanitize_signing_config_ssh_format_agent_loaded(mocker):
+    """When gpg.format=ssh and the key is loaded in the agent, signing stays enabled."""
     fake_run = mocker.patch("pygitgo.auth.account.run_command", side_effect=["true", "ssh"])
+    mock_key = mocker.MagicMock()
+    mock_key.exists.return_value = True
+    mocker.patch("pygitgo.auth.ssh_utils.get_ssh_key_path", return_value=mock_key)
+    mocker.patch("pygitgo.auth.ssh_utils.is_agent_loaded", return_value=True)
     sanitize_signing_config()
     assert fake_run.call_count == 2
     fake_run.assert_any_call(["git", "config", "--global", "commit.gpgsign"])
     fake_run.assert_any_call(["git", "config", "--global", "gpg.format"])
 
+
+def test_sanitize_signing_config_ssh_format_agent_not_loaded(mocker):
+    """When gpg.format=ssh but the agent does not have the key, signing is disabled."""
+    fake_run = mocker.patch(
+        "pygitgo.auth.account.run_command",
+        side_effect=["true", "ssh", None, None]
+    )
+    mock_key = mocker.MagicMock()
+    mock_key.exists.return_value = True
+    mocker.patch("pygitgo.auth.ssh_utils.get_ssh_key_path", return_value=mock_key)
+    mocker.patch("pygitgo.auth.ssh_utils.is_agent_loaded", return_value=False)
+    fake_warning = mocker.patch("pygitgo.auth.account.warning")
+    mocker.patch("pygitgo.auth.account.info")
+    sanitize_signing_config()
+    assert fake_warning.call_count >= 1
 
 def test_sanitize_signing_config_unset_gpg_program(mocker):
     fake_run = mocker.patch("pygitgo.auth.account.run_command", side_effect=["true", "openpgp", None, None])
@@ -119,4 +139,3 @@ def test_sanitize_signing_config_unset_gpg_program_error(mocker):
 
     assert fake_run.call_count == 4
     assert fake_warning.call_count == 2
-

--- a/tests/test_git_core.py
+++ b/tests/test_git_core.py
@@ -283,24 +283,12 @@ def test_get_signing_flags(mocker):
     mock_path = mocker.MagicMock()
     mock_path.exists.return_value = True
     mocker.patch("pygitgo.commands.git_core.get_ssh_key_path", return_value=mock_path)
-    mocker.patch("pygitgo.commands.git_core.is_agent_loaded", return_value=True)
     flags = _get_signing_flags()
     assert len(flags) > 0
 
     # When key file does not exist, no flags returned.
     mock_path.exists.return_value = False
     assert _get_signing_flags() == []
-
-
-def test_get_signing_flags_agent_not_loaded(mocker):
-    """When the agent does not have the key, signing flags are skipped."""
-    mock_path = mocker.MagicMock()
-    mock_path.exists.return_value = True
-    mocker.patch("pygitgo.commands.git_core.get_ssh_key_path", return_value=mock_path)
-    mocker.patch("pygitgo.commands.git_core.is_agent_loaded", return_value=False)
-    mocker.patch("pygitgo.commands.git_core.warning")
-    flags = _get_signing_flags()
-    assert flags == []
 
 def test_git_commit_no_changes(mocker):
     mocker.patch("pygitgo.commands.git_core.run_command", return_value="")

--- a/tests/test_git_core.py
+++ b/tests/test_git_core.py
@@ -145,6 +145,7 @@ def test_git_push_convert_https_to_ssh(mocker):
     )
 
     mocker.patch('pygitgo.commands.git_core.is_ssh_url', return_value=False)
+    mocker.patch('pygitgo.commands.git_core.get_remote_host', return_value='github.com')
     mocker.patch('pygitgo.commands.git_core.check_connection', return_value=True)
     mocker.patch('pygitgo.commands.git_core.convert_https_to_ssh', return_value=url)
 
@@ -152,17 +153,37 @@ def test_git_push_convert_https_to_ssh(mocker):
     git_push(branch)
 
     fake_run.assert_any_call(
-        ["git", "remote", "set-url", "origin", url], 
-        loading_msg="Converting remote from HTTPS to SSH for secure push...",
+        ["git", "remote", "set-url", "origin", url],
+        loading_msg="Converting remote from HTTPS to SSH...",
         ok_text=f"Remote updated to: {url}"
     )
 
     fake_run.assert_called_with(
-        ["git", "push", "-u", "origin", branch], 
+        ["git", "push", "-u", "origin", branch],
         loading_msg=f"Pushing to remote branch '{branch}'...",
         ok_text=f"Pushed to remote branch '{branch}'.",
         err_text="Push failed: verify your remote URL and SSH key, then try again."
     )
+
+
+def test_git_push_non_github_host_skips_conversion(mocker):
+    """For non-GitHub hosts (e.g. Gitea), HTTPS URL is kept as-is."""
+    url = 'https://git.mycompany.com/user/repo.git'
+    fake_run = mocker.patch(
+        'pygitgo.commands.git_core.run_command',
+        side_effect=[url, None]
+    )
+
+    mocker.patch('pygitgo.commands.git_core.is_ssh_url', return_value=False)
+    mocker.patch('pygitgo.commands.git_core.get_remote_host', return_value='git.mycompany.com')
+    mocker.patch('pygitgo.commands.git_core.check_connection', return_value=True)
+    mock_convert = mocker.patch('pygitgo.commands.git_core.convert_https_to_ssh')
+
+    branch = 'main'
+    git_push(branch)
+
+    # convert_https_to_ssh must NOT be called for non-GitHub hosts
+    mock_convert.assert_not_called()
 
 def test_git_commit_skip_staging_does_not_run_git_add(mocker):
     mocker.patch("pygitgo.commands.git_core._get_signing_flags", return_value=[])
@@ -262,11 +283,24 @@ def test_get_signing_flags(mocker):
     mock_path = mocker.MagicMock()
     mock_path.exists.return_value = True
     mocker.patch("pygitgo.commands.git_core.get_ssh_key_path", return_value=mock_path)
+    mocker.patch("pygitgo.commands.git_core.is_agent_loaded", return_value=True)
     flags = _get_signing_flags()
     assert len(flags) > 0
 
+    # When key file does not exist, no flags returned.
     mock_path.exists.return_value = False
     assert _get_signing_flags() == []
+
+
+def test_get_signing_flags_agent_not_loaded(mocker):
+    """When the agent does not have the key, signing flags are skipped."""
+    mock_path = mocker.MagicMock()
+    mock_path.exists.return_value = True
+    mocker.patch("pygitgo.commands.git_core.get_ssh_key_path", return_value=mock_path)
+    mocker.patch("pygitgo.commands.git_core.is_agent_loaded", return_value=False)
+    mocker.patch("pygitgo.commands.git_core.warning")
+    flags = _get_signing_flags()
+    assert flags == []
 
 def test_git_commit_no_changes(mocker):
     mocker.patch("pygitgo.commands.git_core.run_command", return_value="")

--- a/tests/test_ssh_utils.py
+++ b/tests/test_ssh_utils.py
@@ -169,7 +169,7 @@ def test_ensure_ssh_agent_windows_failure(mocker):
     assert fake_try.call_count == 2
     fake_sub.assert_called_once_with(["sc", "start", "ssh-agent"], capture_output=True, timeout=5)
     assert fake_warning.call_count == 1
-    assert fake_info.call_count == 3
+    assert fake_info.call_count == 4
 
 
 def test_ensure_ssh_agent_linux_failure(mocker):
@@ -192,7 +192,7 @@ def test_generate_ssh_key_exists_and_declined(mocker):
 
     with pytest.raises(GitGoError) as exc_info:
         generate_ssh_key("test@example.com")
-    assert "SSH key generation aborted" in str(exc_info.value)
+    assert "SSH key generation canceled" in str(exc_info.value)
 
 
 def test_generate_ssh_key_exists_and_accepted(mocker):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -225,19 +225,16 @@ def test_state_operation_delete_with_id(mocker):
     state_operation(_state_args(action="delete", identifier="1"))
     mock_delete.assert_called_once_with("1")
 
-def test_state_operation_alias_list(mocker):
-    mock_list = mocker.patch("pygitgo.commands.state.state_list")
-    state_operation(_state_args(action_alias="list"))
-    mock_list.assert_called_once()
+def test_state_operation_alias_no_longer_supported(mocker):
+    """Letter aliases were removed. Passing only action_alias raises GitGoError."""
+    with pytest.raises(GitGoError, match="Missing action"):
+        state_operation(_state_args(action_alias="list"))
+
 
 def test_state_operation_delete_all_via_flag(mocker):
     mock_delete = mocker.patch("pygitgo.commands.state.delete_state")
     state_operation(_state_args(action="delete", all=True))
     mock_delete.assert_called_once_with("-a")
-
-def test_state_operation_conflicting_actions():
-    with pytest.raises(GitGoError, match="Conflicting actions"):
-        state_operation(_state_args(action="list", action_alias="save"))
 
 def test_state_operation_all_flag_requires_delete():
     with pytest.raises(GitGoError, match="-a/--all flag is only valid"):
@@ -330,5 +327,5 @@ def test_delete_state_specific_id_fails(mocker):
 
 def test_state_operation_unknown_action(mocker):
     args = _state_args(action="unknown")
-    with pytest.raises(GitGoError, match="Unknown state operation"):
+    with pytest.raises(GitGoError, match="Unknown state action"):
         state_operation(args)


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / internal

## Changes

- `ssh_utils.py`: `gitgo push` no longer tries to convert HTTPS to SSH for non-GitHub hosts (Gitea, GitLab, private servers). It checks the remote hostname first. Only `github.com` gets the SSH conversion. This was the main reason push failed silently on private servers with a different account.
- `ssh_utils.py`: added `is_agent_loaded(key_path)` to check if a key is in the SSH agent. Also added `get_remote_host(url)` to extract the hostname from any remote URL.
- `ssh_utils.py`: `ensure_known_host` now accepts any hostname, not just `github.com`. Old `ensure_github_known_host` kept as an alias so nothing breaks.
- `git_core.py`: `_get_signing_flags` now uses the SSH signing key file from disk directly, and no longer crashes or skips signing based on the SSH agent state.
- `account.py`: `sanitize_signing_config` now checks if the SSH signing key file exists on disk, disabling commit signing gracefully if it is missing to prevent failures.
- `push.py`: when `gitgo push` is run with no arguments, both the default branch and the default message are now shown. Before, only one of them was printed.
- `main.py`: removed the letter aliases (`-l`, `-s`, `-o`, `-d`) from `gitgo state`. They caused confusion for new users who ran `-s` expecting something other than save.
- `main.py`: rewrote help text for `push`, `sync`, `link`, `jump`, `resolve`, `undo`, and `state` in plain language.
- `state.py`: removed alias resolution logic from `state_operation` to match the parser change.
- `README.md`: updated `gitgo push` section to document the both-defaults behavior with an example output. Updated `gitgo state`, `sync`, `link`, `jump`, `resolve`, and `undo` sections to match new help text. Removed the aliases note from state docs.

## Checklist

- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `README.md` updated (if a command was added or changed)
- [x] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)
