### PR TITLE
fix: stop manual spinners in link, init, and repo commands on Ctrl+C …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.10.3] - 2026-08-07
 
 ### Fixed
-- Fixed a bug where hitting Ctrl+C during any command with a loading spinner (like `gitgo pull` or `gitgo jump`) would cause the spinner to keep running and leave broken text on the terminal. The spinner is now stopped cleanly on interrupt.
+- Fixed a bug where hitting Ctrl+C during any command with a loading spinner (like `gitgo pull`, `gitgo jump`, or `gitgo link`) would cause the spinner to keep running and leave broken text on the terminal. The spinner is now stopped cleanly on interrupt, including manual spinners in SSH checks, template downloads, and repo creation.
 - Fixed `gitgo init --template` and `gitgo link` failing with cryptic errors when using non-GitHub URLs (like GitLab or self-hosted servers). The SSH checks and template downloads now correctly detect and handle the remote host.
 
 ---

--- a/src/pygitgo/auth/ssh_utils.py
+++ b/src/pygitgo/auth/ssh_utils.py
@@ -128,10 +128,14 @@ def check_connection(ok_text=None, fail_text=None, host: str = "github.com"):
     spinner = yaspin(**kwargs)
     spinner.start()
 
-    if host == "github.com":
-        raw_output, timed_out, os_error = _get_cached_ssh_response()
-    else:
-        raw_output, timed_out, os_error = _get_ssh_response(host)
+    try:
+        if host == "github.com":
+            raw_output, timed_out, os_error = _get_cached_ssh_response()
+        else:
+            raw_output, timed_out, os_error = _get_ssh_response(host)
+    except KeyboardInterrupt:
+        spinner.stop()
+        raise
 
     connected = (
         not timed_out

--- a/src/pygitgo/commands/init.py
+++ b/src/pygitgo/commands/init.py
@@ -188,6 +188,9 @@ def _download_and_extract_template(template_slug, target_dir):
     try:
         with urllib.request.urlopen(req, timeout=30) as response:
             zip_data = response.read()
+    except KeyboardInterrupt:
+        spinner.stop()
+        raise
     except urllib.error.HTTPError as e:
         if e.code == 404:
             spinner.text = f"Template '{template_slug}' not found on GitHub."
@@ -225,6 +228,9 @@ def _download_and_extract_template(template_slug, target_dir):
                         out.write(src.read())
         spinner.text = "Template extracted successfully."
         spinner.ok("✔")
+    except KeyboardInterrupt:
+        spinner.stop()
+        raise
     except Exception as e:
         spinner.text = f"Failed to extract template: {e}"
         spinner.fail("✖")

--- a/src/pygitgo/commands/repo.py
+++ b/src/pygitgo/commands/repo.py
@@ -140,6 +140,9 @@ def repo_operation(args, silent=False):
         repo_url = repo_.get("clone_url")
         spinner.text = f"Successfully created remote repository: {repo_url}"
         spinner.ok("✔")
+    except KeyboardInterrupt:
+        spinner.stop()
+        raise
     except Exception as e:
         spinner.text = str(e)
         spinner.fail("✖")


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal

## Changes

- `ssh_utils.py`: wrapped `_get_cached_ssh_response` and `_get_ssh_response` inside `check_connection` with a `KeyboardInterrupt` handler so the manual SSH check spinner stops cleanly if the user hits Ctrl+C during `gitgo link`.
- `repo.py`: added a `KeyboardInterrupt` handler to `repo_operation` to ensure the repository creation spinner stops properly.
- `init.py`: added `KeyboardInterrupt` handlers to both the download and extraction phases of `_download_and_extract_template` so the template fetching spinner halts cleanly on interrupt.

## Checklist

- [x] Tested locally and changes work as expected
- [x] `CHANGELOG.md` updated under [`[Unreleased]`](https://github.com/Huerte/GitGo/blob/main/CHANGELOG.md) (Note: Updated directly in `1.10.3` for patch republish)
- [ ] `README.md` updated (if a command was added or changed)
- [x] Tests added or updated (if applicable)
- [x] No existing commands are broken (if they are, describe the impact above)
